### PR TITLE
test: Record traces and videos on retry only

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -65,12 +65,12 @@ if (includesDemo) {
 const config: PlaywrightTestConfig = {
 	testDir: 'e2e',
 	testMatch: '*e2e-spec.ts',
-	retries: 0,
+	retries: 1,
 	reporter: [['list'], ['html', {open: 'never'}]],
 	forbidOnly: isCI,
 	use: {
-		trace: 'retain-on-failure',
-		video: 'on',
+		trace: 'on-all-retries',
+		video: 'on-first-retry',
 	},
 	projects,
 	webServer: frameworks.map((framework) => ({


### PR DESCRIPTION
Just to see what are the performance impact on the test.

Anyway, to would be good to set it this way, as there is no point to record a video for passing tests. The same for the trace, data are recorded during the test even if it's removed if the test passes.