### PR TITLE
Better types for modal actions

### DIFF
--- a/core/lib/modal/modal.ts
+++ b/core/lib/modal/modal.ts
@@ -231,7 +231,7 @@ export interface ModalActions {
 	 * Action to be called when the user clicks on the close button. It closes the modal with the {@link modalCloseButtonClick} result.
 	 * @param event - mouse event
 	 */
-	closeButtonClick(event: MouseEvent): void;
+	closeButtonClick(event: Pick<MouseEvent, never>): void;
 
 	/**
 	 * Action to be called when the user clicks on the modal DOM element (which is supposed to have the size of the full viewport).
@@ -240,7 +240,7 @@ export interface ModalActions {
 	 * (with the {@link modalOutsideClick} result).
 	 * @param event - mouse event
 	 */
-	modalClick(event: MouseEvent): void;
+	modalClick(event: Pick<MouseEvent, 'target' | 'currentTarget'>): void;
 }
 
 /**

--- a/react/lib/modal/Modal.tsx
+++ b/react/lib/modal/Modal.tsx
@@ -22,7 +22,7 @@ const DefaultSlotHeader = (slotContext: ModalContext) => (
 				type="button"
 				className="btn-close"
 				aria-label={slotContext.state.ariaCloseButtonLabel}
-				onClick={slotContext.widget.actions.closeButtonClick as any}
+				onClick={slotContext.widget.actions.closeButtonClick}
 			/>
 		)}
 	</>
@@ -65,7 +65,7 @@ export const Modal = forwardRef(function Modal(props: PropsWithChildren<Partial<
 			<Portal container={state.container}>
 				{state.backdropHidden ? null : <div className={`modal-backdrop ${state.backdropClass}`} ref={refSetBackdrop} />}
 				{state.hidden ? null : (
-					<div className={`modal d-block ${state.modalClass}`} ref={refSetModal} onClick={widget.actions.modalClick as any}>
+					<div className={`modal d-block ${state.modalClass}`} ref={refSetModal} onClick={widget.actions.modalClick}>
 						<div className="modal-dialog">
 							<div className="modal-content">
 								<Slot slotContent={state.slotStructure} props={slotContext} />


### PR DESCRIPTION
This removes the need for "as any" in react.