### PR TITLE
build: deterministic sveltekit build

### DIFF
--- a/demo/svelte.config.js
+++ b/demo/svelte.config.js
@@ -2,6 +2,7 @@ import adapter from '@sveltejs/adapter-static';
 import {vitePreprocess} from '@sveltejs/kit/vite';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import child_process from 'child_process';
 
 const __dirname = fileURLToPath(new URL('./', import.meta.url));
 
@@ -39,6 +40,10 @@ const config = {
 		},
 
 		alias,
+
+		version: {
+			name: child_process.execSync('git rev-parse HEAD').toString().trim(),
+		},
 	},
 };
 


### PR DESCRIPTION
Two builds from the same git commit should produce the same output.

cf https://kit.svelte.dev/docs/configuration#version