### PR TITLE
fix(demo): react custom pagination demo was not consistent with angular and svelte

### DIFF
--- a/e2e/pagination/pagination.e2e-spec.ts
+++ b/e2e/pagination/pagination.e2e-spec.ts
@@ -109,9 +109,13 @@ test.describe.parallel(`Pagination tests`, () => {
 	// TODO add test with the custom template, className...
 	test(`Custom features`, async ({page}) => {
 		const expectedState = {...initCustomState};
-		const paginationPO = new PaginationPO(page, 0);
+		const paginationPO1 = new PaginationPO(page, 0);
+		const paginationPO2 = new PaginationPO(page, 1);
 		await page.goto('#/pagination/custom');
-		await paginationPO.locatorRoot.waitFor();
-		expect(await paginationState(paginationPO)).toEqual(expectedState);
+		await paginationPO1.locatorRoot.waitFor();
+		expect(await paginationState(paginationPO1)).toEqual(expectedState);
+		await paginationPO2.locatorNextButton.click();
+		expectedState.pages = ['A', 'B', 'C', 'D', 'E(current)', 'F'];
+		expect(await paginationState(paginationPO1)).toEqual(expectedState);
 	});
 });

--- a/react/demo/app/samples/pagination/Custom.route.tsx
+++ b/react/demo/app/samples/pagination/Custom.route.tsx
@@ -75,7 +75,7 @@ const PaginationCustom = () => {
 				/>
 				<hr />
 				<p>A pagination with customized pages:</p>
-				<Pagination page={customPage} slotPages={CustomPages} ariaLabel={'Page navigation with customized pages'} />
+				<Pagination page={customPage} onPageChange={setPage} slotPages={CustomPages} ariaLabel={'Page navigation with customized pages'} />
 			</WidgetsDefaultConfig>
 		</>
 	);


### PR DESCRIPTION
Changing the value of the second custom pagination example did not change the value of the first one, unlike the angular and svelte examples.