### PR TITLE
fix(demo): version number displayed in the demo site

### DIFF
--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -2,7 +2,7 @@ import {sveltekit} from '@sveltejs/kit/vite';
 import path from 'path';
 import type {ProxyOptions} from 'vite';
 import {defineConfig} from 'vite';
-import pkg from '../core/package.json';
+import pkg from '../core/lib/package.json';
 import {copySamples} from './scripts/copySamples.plugin';
 import {docExtractor} from './scripts/doc.plugin';
 import {includeSamples} from './scripts/includeSamples.plugin';


### PR DESCRIPTION
After commit 9565ba275d46c0c094e6aeb0966959355bac07a9, the `package.json` file containing the version number is no longer `core/package.json` but `core/lib/package.json`