### PR TITLE
demo: menu improvements

### DIFF
--- a/demo/src/routes/[framework]/menu/SideMenu.svelte
+++ b/demo/src/routes/[framework]/menu/SideMenu.svelte
@@ -9,7 +9,7 @@
 <nav class="w-100 mt-1">
 	{#each menu as { title, submenu }}
 		<strong class="d-flex w-100 align-items-center fw-semibold">{title}</strong>
-		<div>
+		<div class="my-2">
 			{#each submenu as { label, path }}
 				{@const isCurrent = $page.route.id?.startsWith(`/[framework]${path}`)}
 				<a

--- a/demo/src/routes/[framework]/menu/menu.scss
+++ b/demo/src/routes/[framework]/menu/menu.scss
@@ -22,20 +22,23 @@ $mobileMargin: 16px;
 }
 
 .menu-item-sidenav {
-	padding: 0.5rem;
+	padding: 0.1rem 0.5rem;
 	border: 0px solid var(--bs-body-bg);
 	border-width: 2px 0;
 
 	&.active {
-		background-color: var(--bs-secondary-bg);
-		border-color: var(--bs-secondary-bg);
-	}
-
-	&:focus {
-		border-color: var(--bs-primary-border-subtle);
+		color: var(--bs-primary);
 	}
 
 	@include media-breakpoint-down(md) {
+		&:focus {
+			border-color: var(--bs-primary-border-subtle);
+		}
+	}
+
+	@include media-breakpoint-down(md) {
+		padding-top: 0.5rem;
+		padding-bottom: 0.5rem;
 		padding-left: $mobileMargin * 2;
 		padding-right: $mobileMargin * 2;
 	}


### PR DESCRIPTION
While working on the select, I noticed that adding new widgets will end with a really large menu quickly.

This PR do some changes on the sidebar:

- Reduce the padding for breakpoint > md
- Remove the background for the active element, in favor of text-primary
- Remove the blue borders for the focused element for breakpoint > md (kept for the mobile version, it seems to me more visible).

What do you think ?