### PR TITLE
feat: removing dispatch-style events in Svelte

### DIFF
--- a/eslint-plugin/test/svelte-check-props.spec.ts
+++ b/eslint-plugin/test/svelte-check-props.spec.ts
@@ -10,7 +10,7 @@ RuleTester.afterAll = afterAll;
 
 describe('svelte-check-props', () => {
 	const codeTemplate = (scriptContent: string, widgetProps: string, events = '{}') =>
-		`<script lang="ts" context="module">\nimport { createEventDispatcher } from "svelte";\ninterface MyWidgetProps {\n${widgetProps}\n}\ninterface MyWidget {\n\tpatch(props: Partial<MyWidgetProps>): void\n}\nconst callWidgetFactory: (config: any) => MyWidget;\n</script><script lang="ts">\nconst dispatch = createEventDispatcher();\n${scriptContent}\nlet widget = callWidgetFactory({events:${events}});\n</script>`;
+		`<script lang="ts" context="module">\ninterface MyWidgetProps {\n${widgetProps}\n}\ninterface MyWidget {\n\tpatch(props: Partial<MyWidgetProps>): void\n}\nconst callWidgetFactory: (config: any) => MyWidget;\n</script><script lang="ts">\n${scriptContent}\nlet widget = callWidgetFactory({events:${events}});\n</script>`;
 
 	const ruleTester = new RuleTester({
 		plugins: ['svelte'],
@@ -45,13 +45,13 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let someProp1: string | undefined, someProp2: string | undefined;',
 				'someProp2: string; onSomeProp2Change: (event: string) => void;',
-				'{onSomeProp2Change: (event) => {dispatch("someProp2Change", event); someProp2 = event;}}',
+				'{onSomeProp2Change: (event) => {someProp2 = event;}}',
 			),
 			errors: [{messageId: 'extraProp', data: {name: 'someProp1'}}],
 			output: codeTemplate(
 				'export let  someProp2: string | undefined;',
 				'someProp2: string; onSomeProp2Change: (event: string) => void;',
-				'{onSomeProp2Change: (event) => {dispatch("someProp2Change", event); someProp2 = event;}}',
+				'{onSomeProp2Change: (event) => {someProp2 = event;}}',
 			),
 		},
 		{
@@ -59,7 +59,7 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let someProp1: string | undefined, someProp2: string | undefined, someProp3: string | undefined;',
 				'someProp2: string; onSomeProp2Change: (event: string) => void;',
-				'{onSomeProp2Change: (event) => {dispatch("someProp2Change", event); someProp2 = event;}}',
+				'{onSomeProp2Change: (event) => {someProp2 = event;}}',
 			),
 			errors: [
 				{messageId: 'extraProp', data: {name: 'someProp1'}},
@@ -68,7 +68,7 @@ describe('svelte-check-props', () => {
 			output: codeTemplate(
 				'export let  someProp2: string | undefined;',
 				'someProp2: string; onSomeProp2Change: (event: string) => void;',
-				'{onSomeProp2Change: (event) => {dispatch("someProp2Change", event); someProp2 = event;}}',
+				'{onSomeProp2Change: (event) => {someProp2 = event;}}',
 			),
 		},
 		{
@@ -76,13 +76,13 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let someProp1: string | undefined, someProp2: string | undefined;',
 				'someProp1: string; onSomeProp1Change: (event: string) => void;',
-				'{onSomeProp1Change: (event) => {dispatch("someProp1Change", event); someProp1 = event;}}',
+				'{onSomeProp1Change: (event) => {someProp1 = event;}}',
 			),
 			errors: [{messageId: 'extraProp', data: {name: 'someProp2'}}],
 			output: codeTemplate(
 				'export let someProp1: string | undefined;',
 				'someProp1: string; onSomeProp1Change: (event: string) => void;',
-				'{onSomeProp1Change: (event) => {dispatch("someProp1Change", event); someProp1 = event;}}',
+				'{onSomeProp1Change: (event) => {someProp1 = event;}}',
 			),
 		},
 		{
@@ -90,7 +90,7 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let someProp1: string | undefined, someProp2: string | undefined, someProp3: string | undefined;',
 				'someProp1: string; onSomeProp1Change: (event: string) => void;',
-				'{onSomeProp1Change: (event) => {dispatch("someProp1Change", event); someProp1 = event;}}',
+				'{onSomeProp1Change: (event) => {someProp1 = event;}}',
 			),
 			errors: [
 				{messageId: 'extraProp', data: {name: 'someProp2'}},
@@ -99,7 +99,7 @@ describe('svelte-check-props', () => {
 			output: codeTemplate(
 				'export let someProp1: string | undefined;',
 				'someProp1: string; onSomeProp1Change: (event: string) => void;',
-				'{onSomeProp1Change: (event) => {dispatch("someProp1Change", event); someProp1 = event;}}',
+				'{onSomeProp1Change: (event) => {someProp1 = event;}}',
 			),
 		},
 		{
@@ -107,7 +107,7 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let someProp1: string | undefined, someProp2: string | undefined, someProp3: string | undefined, someProp4: string | undefined;',
 				'someProp1: string; onSomeProp1Change: (event: string) => void;',
-				'{onSomeProp1Change: (event) => {dispatch("someProp1Change", event); someProp1 = event;}}',
+				'{onSomeProp1Change: (event) => {someProp1 = event;}}',
 			),
 			errors: [
 				{messageId: 'extraProp', data: {name: 'someProp2'}},
@@ -117,7 +117,7 @@ describe('svelte-check-props', () => {
 			output: codeTemplate(
 				'export let someProp1: string | undefined;',
 				'someProp1: string; onSomeProp1Change: (event: string) => void;',
-				'{onSomeProp1Change: (event) => {dispatch("someProp1Change", event); someProp1 = event;}}',
+				'{onSomeProp1Change: (event) => {someProp1 = event;}}',
 			),
 		},
 		{
@@ -125,7 +125,7 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let someProp1: string | undefined, someProp2: string | undefined, someProp3: string | undefined, someProp4: string | undefined;',
 				'someProp1: string; onSomeProp1Change: (event: string) => void; someProp3: string; onSomeProp3Change: (event: string) => void;',
-				'{onSomeProp1Change: (event) => {dispatch("someProp1Change", event); someProp1 = event;}, onSomeProp3Change: (event) => {dispatch("someProp3Change", event); someProp3 = event;}}',
+				'{onSomeProp1Change: (event) => {someProp1 = event;}, onSomeProp3Change: (event) => {someProp3 = event;}}',
 			),
 			errors: [
 				{messageId: 'extraProp', data: {name: 'someProp2'}},
@@ -134,21 +134,17 @@ describe('svelte-check-props', () => {
 			output: codeTemplate(
 				'export let someProp1: string | undefined,  someProp3: string | undefined;',
 				'someProp1: string; onSomeProp1Change: (event: string) => void; someProp3: string; onSomeProp3Change: (event: string) => void;',
-				'{onSomeProp1Change: (event) => {dispatch("someProp1Change", event); someProp1 = event;}, onSomeProp3Change: (event) => {dispatch("someProp3Change", event); someProp3 = event;}}',
+				'{onSomeProp1Change: (event) => {someProp1 = event;}, onSomeProp3Change: (event) => {someProp3 = event;}}',
 			),
 		},
 		{
 			filename: 'file.svelte',
-			code: codeTemplate(
-				'',
-				'someProp: string; onSomePropChange: (event: string) => void;',
-				'{onSomePropChange: (event) => {dispatch("somePropChange", event); someProp = event;}}',
-			),
+			code: codeTemplate('', 'someProp: string; onSomePropChange: (event: string) => void;', '{onSomePropChange: (event) => {someProp = event;}}'),
 			errors: [{messageId: 'missingBoundProp', data: {name: 'someProp'}}],
 			output: codeTemplate(
 				'\nexport let someProp: string | undefined = undefined;',
 				'someProp: string; onSomePropChange: (event: string) => void;',
-				'{onSomePropChange: (event) => {dispatch("somePropChange", event); someProp = event;}}',
+				'{onSomePropChange: (event) => {someProp = event;}}',
 			),
 		},
 		{
@@ -156,7 +152,7 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'let someProp: string | undefined;',
 				'onSomePropChange: (event: string) => void;',
-				'{onSomePropChange: (event) => {dispatch("somePropChange", event); someProp = event;}}',
+				'{onSomePropChange: (event) => {someProp = event;}}',
 			),
 			errors: [{messageId: 'missingBoundPropInAPI', data: {name: 'someProp'}}],
 		},
@@ -165,17 +161,13 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let someProp: string | undefined;',
 				'onSomePropChange: (event: string) => void;',
-				'{onSomePropChange: (event) => {dispatch("somePropChange", event); someProp = event;}}',
+				'{onSomePropChange: (event) => {someProp = event;}}',
 			),
 			errors: [
 				{messageId: 'extraProp', data: {name: 'someProp'}},
 				{messageId: 'missingBoundPropInAPI', data: {name: 'someProp'}},
 			],
-			output: codeTemplate(
-				'',
-				'onSomePropChange: (event: string) => void;',
-				'{onSomePropChange: (event) => {dispatch("somePropChange", event); someProp = event;}}',
-			),
+			output: codeTemplate('', 'onSomePropChange: (event: string) => void;', '{onSomePropChange: (event) => {someProp = event;}}'),
 			outputError: true,
 		},
 		{
@@ -183,13 +175,13 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let someProp: string;',
 				'someProp: string; onSomePropChange: (event: string) => void;',
-				'{onSomePropChange: (event) => {dispatch("somePropChange", event); someProp = event;}}',
+				'{onSomePropChange: (event) => {someProp = event;}}',
 			),
 			errors: [{messageId: 'invalidPropType', data: {name: 'someProp', expectedType: 'string | undefined', foundType: 'string'}}],
 			output: codeTemplate(
 				'export let someProp: string | undefined;',
 				'someProp: string; onSomePropChange: (event: string) => void;',
-				'{onSomePropChange: (event) => {dispatch("somePropChange", event); someProp = event;}}',
+				'{onSomePropChange: (event) => {someProp = event;}}',
 			),
 		},
 		{
@@ -197,13 +189,13 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let someProp: string | undefined;',
 				'someProp: number; onSomePropChange: (event: number) => void;',
-				'{onSomePropChange: (event) => {dispatch("somePropChange", event); someProp = event;}}',
+				'{onSomePropChange: (event) => {someProp = event;}}',
 			),
 			errors: [{messageId: 'invalidPropType', data: {name: 'someProp', expectedType: 'number | undefined', foundType: 'string | undefined'}}],
 			output: codeTemplate(
 				'export let someProp: number | undefined;',
 				'someProp: number; onSomePropChange: (event: number) => void;',
-				'{onSomePropChange: (event) => {dispatch("somePropChange", event); someProp = event;}}',
+				'{onSomePropChange: (event) => {someProp = event;}}',
 			),
 		},
 		{
@@ -211,45 +203,23 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let someProp;',
 				'someProp: number; onSomePropChange: (event: number) => void;',
-				'{onSomePropChange: (event) => {dispatch("somePropChange", event); someProp = event;}}',
+				'{onSomePropChange: (event) => {someProp = event;}}',
 			),
 			errors: [{messageId: 'invalidPropType', data: {name: 'someProp', expectedType: 'number | undefined', foundType: 'any'}}],
 			output: codeTemplate(
 				'export let someProp: number | undefined;',
 				'someProp: number; onSomePropChange: (event: number) => void;',
-				'{onSomePropChange: (event) => {dispatch("somePropChange", event); someProp = event;}}',
-			),
-		},
-		{
-			filename: 'file.svelte',
-			code: codeTemplate('', 'onSomething: (event: number) => void;'),
-			errors: [{messageId: 'missingDispatchCall', data: {name: 'something', widgetProp: 'onSomething'}}],
-			output: codeTemplate('', 'onSomething: (event: number) => void;', '{\n\tonSomething: (event) => dispatch("something", event),}'),
-		},
-		{
-			filename: 'file.svelte',
-			code: codeTemplate('', 'onSomething: (event: number) => void;', '{\n\tother: 5,\n}'),
-			errors: [{messageId: 'missingDispatchCall', data: {name: 'something', widgetProp: 'onSomething'}}],
-			output: codeTemplate('', 'onSomething: (event: number) => void;', '{\n\tonSomething: (event) => dispatch("something", event),\n\tother: 5,\n}'),
-		},
-		{
-			filename: 'file.svelte',
-			code: codeTemplate('', 'onSomething: (event: number) => void;', '{\n\tonSomething: (evt) => {\n\t\tsomethingElse(evt);\n\t},\n}'),
-			errors: [{messageId: 'missingDispatchCall', data: {name: 'something', widgetProp: 'onSomething'}}],
-			output: codeTemplate(
-				'',
-				'onSomething: (event: number) => void;',
-				'{\n\tonSomething: (evt) => {\n\t\tsomethingElse(evt);\n\t\n\t\tdispatch("something", evt);\n\t},\n}',
+				'{onSomePropChange: (event) => {someProp = event;}}',
 			),
 		},
 		{
 			filename: 'file.svelte',
 			code: codeTemplate('export let something: number | undefined;', 'onSomethingChange: (event: number) => void;\nsomething: number;'),
-			errors: [{messageId: 'missingDispatchCall', data: {name: 'somethingChange', widgetProp: 'onSomethingChange'}}],
+			errors: [{messageId: 'missingBindingAssignment', data: {propBinding: 'something', widgetProp: 'onSomethingChange'}}],
 			output: codeTemplate(
 				'export let something: number | undefined;',
 				'onSomethingChange: (event: number) => void;\nsomething: number;',
-				'{\n\tonSomethingChange: (event) => {\n\t\tsomething = event;\n\t\tdispatch("somethingChange", event);\n\t},}',
+				'{\n\tonSomethingChange: (event) => {\n\t\tsomething = event;\n\t},}',
 			),
 		},
 		{
@@ -259,11 +229,11 @@ describe('svelte-check-props', () => {
 				'onSomethingChange: (event: number) => void;\nsomething: number;',
 				'{\n\tother: 5,\n}',
 			),
-			errors: [{messageId: 'missingDispatchCall', data: {name: 'somethingChange', widgetProp: 'onSomethingChange'}}],
+			errors: [{messageId: 'missingBindingAssignment', data: {propBinding: 'something', widgetProp: 'onSomethingChange'}}],
 			output: codeTemplate(
 				'export let something: number | undefined;',
 				'onSomethingChange: (event: number) => void;\nsomething: number;',
-				'{\n\tonSomethingChange: (event) => {\n\t\tsomething = event;\n\t\tdispatch("somethingChange", event);\n\t},\n\tother: 5,\n}',
+				'{\n\tonSomethingChange: (event) => {\n\t\tsomething = event;\n\t},\n\tother: 5,\n}',
 			),
 		},
 		{
@@ -273,11 +243,11 @@ describe('svelte-check-props', () => {
 				'onSomethingChange: (event: number) => void;\nsomething: number;',
 				'{\n\tonSomethingChange: (evt) => {\n\t\tsomethingElse(evt);\n\t},\n}',
 			),
-			errors: [{messageId: 'missingDispatchCall', data: {name: 'somethingChange', widgetProp: 'onSomethingChange'}}],
+			errors: [{messageId: 'missingBindingAssignment', data: {propBinding: 'something', widgetProp: 'onSomethingChange'}}],
 			output: codeTemplate(
 				'export let something: number | undefined;',
 				'onSomethingChange: (event: number) => void;\nsomething: number;',
-				'{\n\tonSomethingChange: (evt) => {\n\t\tsomethingElse(evt);\n\t\n\t\tsomething = evt;\n\t\tdispatch("somethingChange", evt);\n\t},\n}',
+				'{\n\tonSomethingChange: (evt) => {\n\t\tsomethingElse(evt);\n\t\n\t\tsomething = evt;\n\t},\n}',
 			),
 		},
 		{
@@ -285,13 +255,13 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let something: number | undefined;',
 				'onSomethingChange: (event: number) => void;\nsomething: number;',
-				'{\n\tonSomethingChange: (evt) => {\n\t\tdispatch("somethingChange", evt);\n\t},\n}',
+				'{\n\tonSomethingChange: (evt) => {\n\t\t\n\t},\n}',
 			),
 			errors: [{messageId: 'missingBindingAssignment', data: {propBinding: 'something', widgetProp: 'onSomethingChange'}}],
 			output: codeTemplate(
 				'export let something: number | undefined;',
 				'onSomethingChange: (event: number) => void;\nsomething: number;',
-				'{\n\tonSomethingChange: (evt) => {\n\t\tdispatch("somethingChange", evt);\n\t\n\t\tsomething = evt;\n\t},\n}',
+				'{\n\tonSomethingChange: (evt) => {\n\t\t\n\t\n\t\tsomething = evt;\n\t},\n}',
 			),
 		},
 		{
@@ -299,13 +269,13 @@ describe('svelte-check-props', () => {
 			code: codeTemplate(
 				'export let something: number | undefined;',
 				'onSomethingChange: (event: number) => void;\nsomething: number;',
-				'{\n\tonSomethingChange: (evt) => dispatch("somethingChange", evt),\n}',
+				'{\n\tonSomethingChange: (evt) => callSomething(),\n}',
 			),
 			errors: [{messageId: 'missingBindingAssignment', data: {propBinding: 'something', widgetProp: 'onSomethingChange'}}],
 			output: codeTemplate(
 				'export let something: number | undefined;',
 				'onSomethingChange: (event: number) => void;\nsomething: number;',
-				'{\n\tonSomethingChange: (event) => {\n\t\tsomething = event;\n\t\tdispatch("somethingChange", event);\n\t},\n}',
+				'{\n\tonSomethingChange: (event) => {\n\t\tsomething = event;\n\t},\n}',
 			),
 		},
 		{
@@ -315,25 +285,11 @@ describe('svelte-check-props', () => {
 				'onSomethingChange: (event: number) => void;\nsomething: number;',
 				'{\n\tonSomethingChange: undefined,\n}',
 			),
-			errors: [{messageId: 'missingDispatchCall', data: {name: 'somethingChange', widgetProp: 'onSomethingChange'}}],
+			errors: [{messageId: 'missingBindingAssignment', data: {propBinding: 'something', widgetProp: 'onSomethingChange'}}],
 			output: codeTemplate(
 				'export let something: number | undefined;',
 				'onSomethingChange: (event: number) => void;\nsomething: number;',
-				'{\n\tonSomethingChange: (event) => {\n\t\tsomething = event;\n\t\tdispatch("somethingChange", event);\n\t},\n}',
-			),
-		},
-		{
-			filename: 'file.svelte',
-			code: codeTemplate(
-				'export let something: number | undefined;',
-				'onSomethingChange: (event: number) => void;\nsomething: number;',
-				'{\n\tonSomethingChange: (event) => something = event,\n}',
-			),
-			errors: [{messageId: 'missingDispatchCall', data: {name: 'somethingChange', widgetProp: 'onSomethingChange'}}],
-			output: codeTemplate(
-				'export let something: number | undefined;',
-				'onSomethingChange: (event: number) => void;\nsomething: number;',
-				'{\n\tonSomethingChange: (event) => {\n\t\tsomething = event;\n\t\tdispatch("somethingChange", event);\n\t},\n}',
+				'{\n\tonSomethingChange: (event) => {\n\t\tsomething = event;\n\t},\n}',
 			),
 		},
 	];
@@ -349,6 +305,18 @@ describe('svelte-check-props', () => {
 			},
 			{
 				code: codeTemplate('', ''),
+			},
+			{
+				filename: 'file.svelte',
+				code: codeTemplate('', 'onSomething: (event: number) => void;'),
+			},
+			{
+				filename: 'file.svelte',
+				code: codeTemplate(
+					'export let something: number | undefined;',
+					'onSomethingChange: (event: number) => void;\nsomething: number;',
+					'{\n\tonSomethingChange: (event) => something = event,\n}',
+				),
 			},
 			...invalid
 				.filter(({output, outputError}) => !!output && !outputError)

--- a/svelte/demo/samples/alert/Dynamic.route.svelte
+++ b/svelte/demo/samples/alert/Dynamic.route.svelte
@@ -35,5 +35,5 @@
 {#each $alerts$ as alert (alert)}
 	{@const {dismissible, animationOnInit, animation, type, slotDefault} = alert}
 
-	<Alert {dismissible} {animationOnInit} {animation} {type} {slotDefault} on:hidden={() => alerts$.remove(alert)} />
+	<Alert {dismissible} {animationOnInit} {animation} {type} {slotDefault} onHidden={() => alerts$.remove(alert)} />
 {/each}

--- a/svelte/demo/samples/rating/Default.route.svelte
+++ b/svelte/demo/samples/rating/Default.route.svelte
@@ -6,7 +6,7 @@
 	let left = 0;
 </script>
 
-<Rating bind:rating on:hover={(e) => (hovered = e.detail)} on:leave={(e) => (left = e.detail)} ariaLabel="rating" />
+<Rating bind:rating onHover={(e) => (hovered = e)} onLeave={(e) => (left = e)} ariaLabel="rating" />
 <div>
 	Current rate: <span id="defaultRating">{rating}</span><br />
 	Hovered: <span id="defaultHovered">{hovered}</span><br />

--- a/svelte/headless/config.ts
+++ b/svelte/headless/config.ts
@@ -74,7 +74,7 @@ export const widgetsConfigFactory = <Config extends {[widgetName: string]: objec
 		widgetName?: null | keyof Config;
 		$$slots: SlotsPresent<WidgetProps<W>>;
 		defaultConfig?: Partial<WidgetProps<W>> | ReadableSignal<Partial<WidgetProps<W>> | undefined>;
-		events: Pick<WidgetProps<W>, keyof WidgetProps<W> & `on${string}`>;
+		events: Pick<WidgetProps<W>, keyof WidgetProps<W> & `on${string}Change`>;
 	}) =>
 		callWidgetFactoryWithConfig({
 			factory,

--- a/svelte/headless/slotTypes.ts
+++ b/svelte/headless/slotTypes.ts
@@ -5,12 +5,6 @@ export const useSvelteSlot = Symbol('useSvelteSlot');
 
 export type WidgetPropsProps<Props extends object> = Partial<Props>;
 
-export type WidgetPropsEvents<Props extends object> = {
-	[K in keyof Props & `on${string}` as K extends `on${infer U}` ? Uncapitalize<U> : never]: NonNullable<Props[K]> extends (arg: infer U) => void
-		? CustomEvent<U>
-		: never;
-};
-
 export type WidgetPropsSlots<Props extends object> = {
 	[K in keyof Props & `slot${string}` as K extends `slot${infer U}` ? Uncapitalize<U> : never]: Props[K] extends SlotContent<infer U> ? U : never;
 };

--- a/svelte/headless/utils.ts
+++ b/svelte/headless/utils.ts
@@ -2,7 +2,6 @@ import type {Widget, WidgetFactory, WidgetProps} from '@agnos-ui/core';
 import {findChangedProperties, toReadableStore} from '@agnos-ui/core';
 import type {ReadableSignal, WritableSignal} from '@amadeus-it-group/tansu';
 import {asReadable, computed, writable} from '@amadeus-it-group/tansu';
-import {createEventDispatcher as svelteCreateEventDispatcher} from 'svelte';
 import type {SlotContent, SlotSvelteComponent, SlotsPresent} from './slotTypes';
 import {useSvelteSlot} from './slotTypes';
 
@@ -16,9 +15,6 @@ export function createPatchChangedProps<T extends object>(patchFn: (arg: Partial
 		}
 	};
 }
-
-export const createEventDispatcher = <T extends object>() =>
-	svelteCreateEventDispatcher<{[K in keyof T]: T[K] extends CustomEvent<infer U> ? U : never}>();
 
 /**
  * Merges two functions.
@@ -61,7 +57,7 @@ export const callWidgetFactoryWithConfig = <W extends Widget>({
 	$$slots: SlotsPresent<WidgetProps<W>>;
 	defaultConfig?: Partial<WidgetProps<W>> | ReadableSignal<Partial<WidgetProps<W>> | undefined>;
 	widgetConfig?: null | undefined | ReadableSignal<Partial<WidgetProps<W>> | undefined>;
-	events: Pick<WidgetProps<W>, keyof WidgetProps<W> & `on${string}`>;
+	events: Pick<WidgetProps<W>, keyof WidgetProps<W> & `on${string}Change`>;
 }): W & {patchChangedProps: W['patch']} => {
 	const defaultConfig$ = toReadableStore(defaultConfig);
 	const processedSlots: any = {};
@@ -71,7 +67,7 @@ export const callWidgetFactoryWithConfig = <W extends Widget>({
 		}
 	}
 	const props: {[key in keyof WidgetProps<W>]: WritableSignal<WidgetProps<W>[key]>} = {} as any;
-	for (const event of Object.keys(events) as (keyof WidgetProps<W> & `on${string}`)[]) {
+	for (const event of Object.keys(events) as (keyof WidgetProps<W> & `on${string}Change`)[]) {
 		props[event] = eventStore(events[event] as any) as any;
 	}
 	const widget = factory({

--- a/svelte/lib/accordion/Accordion.svelte
+++ b/svelte/lib/accordion/Accordion.svelte
@@ -1,15 +1,13 @@
 <script context="module" lang="ts">
-	import type {AccordionProps as Props, AccordionSlots as Slots, WidgetPropsEvents, WidgetPropsProps} from '@agnos-ui/svelte-headless';
-	import {callWidgetFactory, createAccordion, createEventDispatcher} from '@agnos-ui/svelte-headless';
+	import type {AccordionProps as Props, AccordionSlots as Slots, WidgetPropsProps} from '@agnos-ui/svelte-headless';
+	import {callWidgetFactory, createAccordion} from '@agnos-ui/svelte-headless';
 	import {setAccordionApi} from './accordion';
 </script>
 
 <script lang="ts">
 	type $$Props = WidgetPropsProps<Props>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	type $$Events = WidgetPropsEvents<Props>;
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Slots = {default: Record<string, never>} & Slots; // eslint-disable-line @typescript-eslint/no-unused-vars
-	const dispatch = createEventDispatcher<$$Events>();
 
 	export let itemVisible: boolean | undefined = undefined;
 	const widget = callWidgetFactory({
@@ -19,15 +17,6 @@
 		events: {
 			onItemVisibleChange: (event) => {
 				itemVisible = event;
-				dispatch('itemVisibleChange', event);
-			},
-			onItemHidden: () => dispatch('itemHidden'),
-			onItemShown: () => dispatch('itemShown'),
-			onShown: (id: string) => {
-				dispatch('shown', id);
-			},
-			onHidden: (id: string) => {
-				dispatch('hidden', id);
 			},
 		},
 	});

--- a/svelte/lib/accordion/Item.svelte
+++ b/svelte/lib/accordion/Item.svelte
@@ -1,6 +1,6 @@
 <script context="module" lang="ts">
-	import type {AccordionItemProps as Props, AccordionSlots as Slots, WidgetPropsEvents, WidgetPropsProps} from '@agnos-ui/svelte-headless';
-	import {Slot, callWidgetFactory, createEventDispatcher, toSlotContextWidget} from '@agnos-ui/svelte-headless';
+	import type {AccordionItemProps as Props, AccordionSlots as Slots, WidgetPropsProps} from '@agnos-ui/svelte-headless';
+	import {Slot, callWidgetFactory, toSlotContextWidget} from '@agnos-ui/svelte-headless';
 	import {onMount} from 'svelte';
 	import ItemDefaultStructure from './ItemDefaultStructure.svelte';
 	import {getAccordionApi} from './accordion';
@@ -13,10 +13,8 @@
 <script lang="ts">
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Props = WidgetPropsProps<Props>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	type $$Events = WidgetPropsEvents<Props>;
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Slots = Slots; // eslint-disable-line @typescript-eslint/no-unused-vars
-	const dispatch = createEventDispatcher<$$Events>();
 
 	const accordionApi = getAccordionApi();
 	const {registerItem} = accordionApi;
@@ -28,10 +26,7 @@
 		events: {
 			onItemVisibleChange: (event) => {
 				itemVisible = event;
-				dispatch('itemVisibleChange', event);
 			},
-			onItemHidden: () => dispatch('itemHidden'),
-			onItemShown: () => dispatch('itemShown'),
 		},
 	});
 	const {

--- a/svelte/lib/alert/Alert.svelte
+++ b/svelte/lib/alert/Alert.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" context="module">
-	import type {AlertProps as Props, AlertSlots as Slots, WidgetPropsEvents, WidgetPropsProps} from '@agnos-ui/svelte-headless';
-	import {Slot, callWidgetFactory, createAlert, createEventDispatcher} from '@agnos-ui/svelte-headless';
+	import type {AlertProps as Props, AlertSlots as Slots, WidgetPropsProps} from '@agnos-ui/svelte-headless';
+	import {Slot, callWidgetFactory, createAlert} from '@agnos-ui/svelte-headless';
 	import AlertDefaultStructure from './AlertDefaultStructure.svelte';
 
 	const defaultConfig: Partial<Props> = {
@@ -10,20 +10,15 @@
 
 <script lang="ts">
 	type $$Props = WidgetPropsProps<Props>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	type $$Events = WidgetPropsEvents<Props>;
 	type $$Slots = Slots; // eslint-disable-line @typescript-eslint/no-unused-vars
-	const dispatch = createEventDispatcher<$$Events>();
 	const widget = callWidgetFactory({
 		factory: createAlert,
 		widgetName: 'alert',
 		$$slots,
 		defaultConfig,
 		events: {
-			onShown: () => dispatch('shown'),
-			onHidden: () => dispatch('hidden'),
 			onVisibleChange: (event) => {
 				visible = event;
-				dispatch('visibleChange', event);
 			},
 		},
 	});

--- a/svelte/lib/modal/Modal.svelte
+++ b/svelte/lib/modal/Modal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" context="module">
-	import type {ModalWidget, ModalProps as Props, ModalSlots as Slots, WidgetPropsEvents, WidgetPropsProps} from '@agnos-ui/svelte-headless';
-	import {Slot, callWidgetFactory, createEventDispatcher, createModal, toSlotContextWidget} from '@agnos-ui/svelte-headless';
+	import type {ModalWidget, ModalProps as Props, ModalSlots as Slots, WidgetPropsProps} from '@agnos-ui/svelte-headless';
+	import {Slot, callWidgetFactory, createModal, toSlotContextWidget} from '@agnos-ui/svelte-headless';
 	import ModalDefaultHeader from './ModalDefaultHeader.svelte';
 	import ModalDefaultStructure from './ModalDefaultStructure.svelte';
 
@@ -14,10 +14,8 @@
 	type Data = $$Generic; // eslint-disable-line no-undef
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Props = WidgetPropsProps<Props<Data>>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	type $$Events = WidgetPropsEvents<Props<Data>>;
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Slots = Slots<Data>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	const dispatch = createEventDispatcher<$$Events>();
 
 	export let visible: boolean | undefined = undefined;
 
@@ -27,19 +25,8 @@
 		$$slots,
 		defaultConfig,
 		events: {
-			onShown: () => dispatch('shown'),
-			onHidden: () => dispatch('hidden'),
-			onBeforeClose: (event) => {
-				const shouldContinue = dispatch('beforeClose', event, {
-					cancelable: true,
-				});
-				if (!shouldContinue) {
-					event.cancel = true;
-				}
-			},
 			onVisibleChange: (event) => {
 				visible = event;
-				dispatch('visibleChange', event);
 			},
 		},
 	});

--- a/svelte/lib/pagination/Pagination.svelte
+++ b/svelte/lib/pagination/Pagination.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" context="module">
-	import type {PaginationProps as Props, PaginationSlots as Slots, WidgetPropsEvents, WidgetPropsProps} from '@agnos-ui/svelte-headless';
-	import {Slot, callWidgetFactory, createEventDispatcher, createPagination, toSlotContextWidget} from '@agnos-ui/svelte-headless';
+	import type {PaginationProps as Props, PaginationSlots as Slots, WidgetPropsProps} from '@agnos-ui/svelte-headless';
+	import {Slot, callWidgetFactory, createPagination, toSlotContextWidget} from '@agnos-ui/svelte-headless';
 	import PaginationDefaultPages from './PaginationDefaultPages.svelte';
 
 	const defaultConfig: Partial<Props> = {
@@ -11,10 +11,8 @@
 <script lang="ts">
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Props = WidgetPropsProps<Props>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	type $$Events = WidgetPropsEvents<Props>;
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Slots = Slots; // eslint-disable-line @typescript-eslint/no-unused-vars
-	const dispatch = createEventDispatcher<$$Events>();
 
 	/**
 	 *  The current page.
@@ -31,7 +29,6 @@
 		events: {
 			onPageChange: (value: number) => {
 				page = value;
-				dispatch('pageChange', value);
 			},
 		},
 	});

--- a/svelte/lib/rating/Rating.svelte
+++ b/svelte/lib/rating/Rating.svelte
@@ -1,15 +1,13 @@
 <script lang="ts" context="module">
-	import type {RatingProps as Props, RatingSlots as Slots, WidgetPropsEvents, WidgetPropsProps} from '@agnos-ui/svelte-headless';
-	import {Slot, callWidgetFactory, createEventDispatcher, createRating} from '@agnos-ui/svelte-headless';
+	import type {RatingProps as Props, RatingSlots as Slots, WidgetPropsProps} from '@agnos-ui/svelte-headless';
+	import {Slot, callWidgetFactory, createRating} from '@agnos-ui/svelte-headless';
 </script>
 
 <script lang="ts">
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Props = WidgetPropsProps<Props>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	type $$Events = WidgetPropsEvents<Props>;
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Slots = Slots; // eslint-disable-line @typescript-eslint/no-unused-vars
-	const dispatch = createEventDispatcher<$$Events>();
 
 	export let rating: number | undefined = undefined;
 
@@ -18,11 +16,8 @@
 		widgetName: 'rating',
 		$$slots,
 		events: {
-			onHover: (value: number) => dispatch('hover', value),
-			onLeave: (value: number) => dispatch('leave', value),
 			onRatingChange: (value: number) => {
 				rating = value;
-				dispatch('ratingChange', value);
 			},
 		},
 	});

--- a/svelte/lib/select/Select.svelte
+++ b/svelte/lib/select/Select.svelte
@@ -1,16 +1,14 @@
 <script lang="ts" context="module">
-	import type {SelectProps as Props, SelectWidget, SelectSlots as Slots, WidgetPropsEvents, WidgetPropsProps} from '@agnos-ui/svelte-headless';
-	import {Slot, callWidgetFactory, createEventDispatcher, createSelect} from '@agnos-ui/svelte-headless';
+	import type {SelectProps as Props, SelectWidget, SelectSlots as Slots, WidgetPropsProps} from '@agnos-ui/svelte-headless';
+	import {Slot, callWidgetFactory, createSelect} from '@agnos-ui/svelte-headless';
 </script>
 
 <script lang="ts">
 	type Item = $$Generic; // eslint-disable-line no-undef
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Props = WidgetPropsProps<Props<Item>>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	type $$Events = WidgetPropsEvents<Props<Item>>;
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Slots = Slots<Item>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	const dispatch = createEventDispatcher<$$Events>();
 
 	export let open: boolean | undefined = false;
 	export let filterText: string | undefined = undefined;
@@ -23,17 +21,12 @@
 		events: {
 			onOpenChange: function (isOpen: boolean): void {
 				open = isOpen;
-				dispatch('openChange', isOpen);
-
-				open = isOpen;
 			},
 			onSelectedChange: (newSelection) => {
 				selected = newSelection;
-				dispatch('selectedChange', newSelection);
 			},
 			onFilterTextChange: (value) => {
 				filterText = value;
-				dispatch('filterTextChange', value);
 			},
 		},
 	});

--- a/svelte/lib/slider/Slider.svelte
+++ b/svelte/lib/slider/Slider.svelte
@@ -1,13 +1,11 @@
 <script lang="ts" context="module">
-	import type {SliderProps as Props, WidgetPropsEvents, WidgetPropsProps} from '@agnos-ui/svelte-headless';
-	import {callWidgetFactory, createEventDispatcher, createSlider} from '@agnos-ui/svelte-headless';
+	import type {SliderProps as Props, WidgetPropsProps} from '@agnos-ui/svelte-headless';
+	import {callWidgetFactory, createSlider} from '@agnos-ui/svelte-headless';
 </script>
 
 <script lang="ts">
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	type $$Props = WidgetPropsProps<Props>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	type $$Events = WidgetPropsEvents<Props>;
-	const dispatch = createEventDispatcher<$$Events>();
 
 	export let values: number[] | undefined = undefined;
 
@@ -18,7 +16,6 @@
 		events: {
 			onValuesChange: function (newValues: number[]): void {
 				values = newValues;
-				dispatch('valuesChange', values);
 			},
 		},
 	});


### PR DESCRIPTION
`createEventDispatcher` is [deprecated in Svelte 5](https://svelte-5-preview.vercel.app/docs/event-handlers), it is now recommended to use simple props.

Following #225, this PR completely removes support for on:something={...} events in AgnosUI components (in favor of only onSomething={...} as in React). This simplifies a lot the code.