### PR TITLE
fix: height of scrollable content container

### DIFF
--- a/demo/src/routes/+layout.svelte
+++ b/demo/src/routes/+layout.svelte
@@ -79,7 +79,7 @@
 
 	.agnos-ui {
 		width: 100vw;
-		height: 100vh;
+		height: 100dvh;
 		display: grid;
 		grid-template-areas:
 			'top'


### PR DESCRIPTION
While opening the landing page on mobile, scrolling to the bottom would not show the Accessibility section content.
It was due do the fact we were setting the container to height 100vh instead of 100dvh