### PR TITLE
core: enable linter on Promise

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,8 @@
 	],
 	"rules": {
 		"prefer-const": ["error", {"destructuring": "all"}],
+		"@typescript-eslint/no-floating-promises": "error",
+		"@typescript-eslint/no-misused-promises": ["error", {"checksVoidReturn": false}],
 		"@typescript-eslint/no-unused-vars": ["error", {"vars": "all", "args": "none", "ignoreRestSiblings": false}],
 		"@typescript-eslint/no-non-null-assertion": "off",
 		"@typescript-eslint/no-explicit-any": "off",

--- a/angular/demo/src/app/samples/modal/component.route.ts
+++ b/angular/demo/src/app/samples/modal/component.route.ts
@@ -12,6 +12,6 @@ export default class DemoContentModalComponent {
 	readonly modalService = inject(ModalService);
 
 	openModal() {
-		this.modalService.open<ModalData>({slotTitle: 'Hi there!', slotDefault: CustomContentComponent, contentData: {name: 'World'}});
+		void this.modalService.open<ModalData>({slotTitle: 'Hi there!', slotDefault: CustomContentComponent, contentData: {name: 'World'}});
 	}
 }

--- a/angular/demo/src/app/samples/transition/innerComponent.component.ts
+++ b/angular/demo/src/app/samples/transition/innerComponent.component.ts
@@ -121,7 +121,7 @@ export class InnerComponent {
 	changeTransition(newTransition: TransitionFn) {
 		// Make sure the element is removed from the DOM
 		// so that it does not keep state from the previous transition
-		this.transition.api.toggle(false, false);
+		void this.transition.api.toggle(false, false);
 		paramRemoveFromDom$.set(true);
 		paramTransition$.set(newTransition);
 	}

--- a/angular/demo/src/app/utils.ts
+++ b/angular/demo/src/app/utils.ts
@@ -46,7 +46,7 @@ export function hashChangeHook(propsCallback: (props: any) => void) {
 	}
 
 	effect(() => {
-		callPropsCallback(getPropValues(hashConfig$().props));
+		void callPropsCallback(getPropValues(hashConfig$().props));
 	});
 }
 

--- a/angular/headless/src/utils/directive.ts
+++ b/angular/headless/src/utils/directive.ts
@@ -28,7 +28,7 @@ export const useDirectiveForHost = <T>(use?: AgnosUIDirective<T>, params?: T) =>
 
 	async function update(newUse?: AgnosUIDirective<T>, newParams?: T) {
 		if (newUse !== use) {
-			destroyDirectiveInstance();
+			void destroyDirectiveInstance();
 			use = newUse;
 			params = newParams;
 			if (newUse) {
@@ -62,6 +62,6 @@ export class UseDirective<T> implements OnChanges {
 	#useDirective = useDirectiveForHost<T>();
 
 	ngOnChanges() {
-		this.#useDirective.update(this.use, this.params);
+		void this.#useDirective.update(this.use, this.params);
 	}
 }

--- a/angular/headless/src/utils/zone.ts
+++ b/angular/headless/src/utils/zone.ts
@@ -38,7 +38,7 @@ export class ZoneWrapper {
 					this.#runNeeded = true;
 					if (!this.#runPlanned) {
 						this.#runPlanned = true;
-						(async () => {
+						void (async () => {
 							await 0;
 							this.#runPlanned = false;
 							if (this.#runNeeded) {

--- a/code-coverage/lib/vitestProvider.ts
+++ b/code-coverage/lib/vitestProvider.ts
@@ -19,7 +19,7 @@ const customCoverageProviderModule: CoverageProviderModule = {
 			async onAfterSuiteRun({coverage}: AfterSuiteRunMeta) {
 				if (coverage) {
 					const {default: reportCoverage} = await import('./reportCoverage');
-					reportCoverage(ctx!.config.root, JSON.stringify(coverage));
+					await reportCoverage(ctx!.config.root, JSON.stringify(coverage));
 				}
 			},
 			async reportCoverage(reportContext?: ReportContext) {

--- a/core/src/components/modal/modal.spec.ts
+++ b/core/src/components/modal/modal.spec.ts
@@ -100,7 +100,7 @@ describe('modal', () => {
 		const promise = modal.api.open();
 		// should not close the modal:
 		modal.actions.modalClick({currentTarget: element, target: element} as any as MouseEvent);
-		promise.finally(() => (settled = true));
+		void promise.finally(() => (settled = true));
 		await new Promise((resolve) => setTimeout(resolve, 100));
 		directive?.destroy?.();
 		expect(settled).toBe(false);
@@ -125,7 +125,7 @@ describe('modal', () => {
 		// should not close the modal:
 		modal.api.close(null);
 		expect(onBeforeCloseCalled).toBe(1);
-		promise.finally(() => (settled = true));
+		void promise.finally(() => (settled = true));
 		await new Promise((resolve) => setTimeout(resolve, 100));
 		directive?.destroy?.();
 		expect(settled).toBe(false);

--- a/core/src/services/transitions/baseTransitions.spec.ts
+++ b/core/src/services/transitions/baseTransitions.spec.ts
@@ -79,7 +79,7 @@ describe(`createTransition`, () => {
 		});
 		const directiveInstance = transitionInstance.directives.directive(element);
 		const transition1 = transitionInstance.api.show();
-		transition1.finally(() => {
+		void transition1.finally(() => {
 			throw new Error('transition1 is expected not to resolve');
 		});
 		events.push('afterRunTransition1');
@@ -119,14 +119,14 @@ describe(`createTransition`, () => {
 		});
 		const directiveInstance = transitionInstance.directives.directive(element);
 		const transition1 = transitionInstance.api.show();
-		transition1.finally(() => {
+		void transition1.finally(() => {
 			throw new Error('transition1 is expected not to resolve');
 		});
 		events.push('afterRunTransition1');
 		await new Promise((resolve) => setTimeout(resolve, 2));
 		events.push('afterTimeoutTransition1');
 		const transition2 = transitionInstance.api.hide();
-		transition2.finally(() => {
+		void transition2.finally(() => {
 			throw new Error('transition2 is expected not to resolve');
 		});
 		events.push('afterRunTransition2');
@@ -177,7 +177,7 @@ describe(`createTransition`, () => {
 		const transition1 = transitionInstance.api.show();
 		events.push('afterRunTransition1');
 		const transition2 = transitionInstance.api.show();
-		transition1.finally(() => {
+		void transition1.finally(() => {
 			throw new Error('transition1 is expected not to resolve');
 		});
 		events.push('afterRunTransition2');

--- a/core/src/services/transitions/cssTransitions.spec.ts
+++ b/core/src/services/transitions/cssTransitions.spec.ts
@@ -168,7 +168,7 @@ describe(`createCSSTransition`, () => {
 		const timeBefore = performance.now();
 		const directiveInstance = cssTransition.directives.directive(element);
 		const promise1 = cssTransition.api.show();
-		promise1.finally(() => {
+		void promise1.finally(() => {
 			throw new Error('promise1 is expected not to resolve');
 		});
 		await new Promise((resolve) => setTimeout(resolve, 200));

--- a/core/src/services/transitions/simpleClassTransition.spec.ts
+++ b/core/src/services/transitions/simpleClassTransition.spec.ts
@@ -65,7 +65,7 @@ describe('createSimpleClassTransition', () => {
 		checkClasses(['anim', 'anim-hide']);
 		await promise2;
 		checkClasses(['hide']);
-		promise1.finally(() => {
+		void promise1.finally(() => {
 			throw new Error('promise1 is expected not to resolve');
 		});
 	});
@@ -80,7 +80,7 @@ describe('createSimpleClassTransition', () => {
 		checkClasses(['anim', 'anim-show']);
 		await promise2;
 		checkClasses(['show']);
-		promise1.finally(() => {
+		void promise1.finally(() => {
 			throw new Error('promise1 is expected not to resolve');
 		});
 	});

--- a/core/src/utils/internal/promise.spec.ts
+++ b/core/src/utils/internal/promise.spec.ts
@@ -258,7 +258,7 @@ describe(`promiseFromStore`, () => {
 		const res = promiseFromStore(store);
 		expect(onUse).toHaveBeenCalledTimes(1);
 		expect(onUnsubscribe).not.toHaveBeenCalled();
-		res.promise.finally(() => {
+		void res.promise.finally(() => {
 			throw new Error('res.promise is expected not to resolve');
 		});
 		// non-truthy values should not trigger promise resolution:
@@ -290,7 +290,7 @@ describe(`promiseFromTimeout`, () => {
 	test(`calling unsubscribe`, async () => {
 		clearTimeoutSpy.mockClear();
 		const res = promiseFromTimeout(100);
-		res.promise.finally(() => {
+		void res.promise.finally(() => {
 			throw new Error('res.promise is expected not to resolve');
 		});
 		await new Promise((resolve) => setTimeout(resolve, 20));
@@ -322,7 +322,7 @@ describe(`promiseFromEvent`, () => {
 		const removeEventListener = vi.spyOn(target, 'removeEventListener');
 		const res = promiseFromEvent(target, 'something');
 		otherTarget.dispatchEvent(new Event('something', {bubbles: true})); // not the right target, should be ignored
-		res.promise.finally(() => {
+		void res.promise.finally(() => {
 			throw new Error('res.promise is expected not to resolve');
 		});
 		res.unsubscribe();

--- a/demo/src/lib/layout/Sample.svelte
+++ b/demo/src/lib/layout/Sample.svelte
@@ -69,7 +69,7 @@
 	async function getCode(showCode: boolean, frameworkName: Frameworks, sample: SampleInfo, fileName: string) {
 		code = showCode ? await sample.files[frameworkName].files[fileName]() : '';
 	}
-	$: getCode(showCode, $selectedFramework$!, sample, selectedFileName);
+	$: void getCode(showCode, $selectedFramework$!, sample, selectedFileName);
 
 	$: sampleBaseUrl = `${$pathToRoot$}${$selectedFramework$}/samples/#/${path}`;
 	$: sampleUrl = sampleBaseUrl + (urlParameters ? `#${JSON.stringify(urlParameters)}` : '');

--- a/demo/src/routes/+layout.svelte
+++ b/demo/src/routes/+layout.svelte
@@ -12,7 +12,7 @@
 	import MobileMenu from './[framework]/menu/MobileMenu.svelte';
 
 	const onServiceWorkerUpdate = () => {
-		updated.check();
+		void updated.check();
 	};
 
 	$: isMainPage = $routeLevel$ === 0;

--- a/demo/src/service-worker.ts
+++ b/demo/src/service-worker.ts
@@ -31,7 +31,7 @@ self.addEventListener('install', (event) => {
 				withHash.map(async (url) => {
 					const response = await caches.match(url);
 					if (response?.ok) {
-						cache.put(url, response);
+						void cache.put(url, response);
 					} else {
 						missingWithHash.push(url);
 					}

--- a/e2e/fixture.ts
+++ b/e2e/fixture.ts
@@ -17,7 +17,7 @@ export const test = base.extend<FixtureOptions>({
 				return JSON.stringify((window as any).__coverage__);
 			});
 			if (coverage && browserName === 'chromium') {
-				reportCoverage(__dirname, coverage);
+				await reportCoverage(__dirname, coverage);
 			}
 		},
 		{auto: true},

--- a/e2e/floatingUI/floatingUI.e2e-spec.ts
+++ b/e2e/floatingUI/floatingUI.e2e-spec.ts
@@ -10,7 +10,7 @@ test.describe(`FloatingUI tests`, () => {
 		const demoPO = new FloatingUIDemoPO(page);
 		await expect(demoPO.locatorPopover).toBeVisible();
 		await demoPO.locatorTogglePopoverButton.click();
-		expect(demoPO.locatorPopover).not.toBeVisible();
+		await expect(demoPO.locatorPopover).not.toBeVisible();
 		await demoPO.locatorTogglePopoverButton.click();
 		await expect(demoPO.locatorPopover).toBeVisible();
 		expect(await demoPO.locatorPopover.boundingBox()).toEqual({x: 211, y: 32, width: 250, height: 55});

--- a/react/demo/src/app/samples/transition/InnerComponent.tsx
+++ b/react/demo/src/app/samples/transition/InnerComponent.tsx
@@ -34,7 +34,7 @@ const InnerComponent = () => {
 	const changeTransition = (newTransition: TransitionFn) => {
 		// Make sure the element is removed from the DOM
 		// so that it does not keep state from the previous transition
-		transitionWidget.api.toggle(false, false);
+		void transitionWidget.api.toggle(false, false);
 		paramRemoveFromDom$.set(true);
 		paramTransition$.set(newTransition);
 	};

--- a/svelte/demo/src/app/samples/transition/InnerComponent.svelte
+++ b/svelte/demo/src/app/samples/transition/InnerComponent.svelte
@@ -33,7 +33,7 @@
 	const changeTransition = (newTransition: TransitionFn) => {
 		// Make sure the element is removed from the DOM
 		// so that it does not keep state from the previous transition
-		toggle(false, false);
+		void toggle(false, false);
 		$paramRemoveFromDom$ = true;
 		$paramTransition$ = newTransition;
 	};


### PR DESCRIPTION
The PR does not pass yet, this is just to discuss about it first.

It enables two rules:

  - https://typescript-eslint.io/rules/no-floating-promises/
  - https://typescript-eslint.io/rules/no-misused-promises/

With this PR, promise need to be explicitly handled. For example:

```typescript
  await getAsyncFn();

  // or, if we don't want to wait:
  void getAsyncFn();
```

The point is to avoid issues/mistakes in test as [here](https://github.com/AmadeusITGroup/AgnosUI/blob/ad8da0864a080db682d78e1220f9c37deadd348b/e2e/floatingUI/floatingUI.e2e-spec.ts#L13), where ```toBeVisible()``` is not awaited.

But probably having this rule enabled everywhere is safer.

