### PR TITLE
fix: initial 500 error when navigating from home page

### DIFF
--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -56,4 +56,16 @@ export default defineConfig({
 	define: {
 		'import.meta.env.AGNOSUI_VERSION': version,
 	},
+	optimizeDeps: {
+		include: [
+			'@amadeus-it-group/tansu',
+			'highlight.js/lib/core',
+			'highlight.js/lib/languages/typescript',
+			'highlight.js/lib/languages/css',
+			'highlight.js/lib/languages/scss',
+			'highlight.js/lib/languages/xml',
+			'highlight.js/lib/languages/bash',
+			'@floating-ui/dom',
+		],
+	},
 });


### PR DESCRIPTION
Launching the Vite server in local would result in a temporary 500 error navigating from the home page to any other page.
This is due to the fact some dependencies (highlight.js, floating-ui and tansu) are needed everywhere but the home page, thus vite would not optimize the dependencies at initial startup.

This PR proposes to list those dependencies as "to always optimize".