### PR TITLE
feat: demo reload after app update

### DIFF
--- a/demo/src/routes/+layout.svelte
+++ b/demo/src/routes/+layout.svelte
@@ -50,7 +50,7 @@
 </svelte:head>
 -->
 
-<div class="agnos-ui">
+<div class="agnos-ui" data-sveltekit-reload={$updated ? '' : 'off'}>
 	<nav class="demo-nav-top navbar navbar-dark bg-primary bg-gradient">
 		<div class="container-fluid">
 			<a class="navbar-brand" href={$pathToRoot$}> AgnosUI </a>

--- a/demo/svelte.config.js
+++ b/demo/svelte.config.js
@@ -50,6 +50,7 @@ const config = {
 
 		version: {
 			name: child_process.execSync('git rev-parse HEAD').toString().trim(),
+			pollInterval: 5_000,
 		},
 	},
 };


### PR DESCRIPTION
When we publish a new version of the demo to ```latest```, we do not properly refresh the app.
This is solved by setting a pollInterval value superior to 0 in the svelte.config.js (see [the config doc](https://kit.svelte.dev/docs/configuration#version)).