### PR TITLE
feat: remove eslint disable from svelte samples

### DIFF
--- a/svelte/.eslintrc.json
+++ b/svelte/.eslintrc.json
@@ -36,7 +36,11 @@
 		{
 			"files": ["demo/**"],
 			"rules": {
-				"@agnos-ui/check-replace-imports": ["error", "@agnos-ui/svelte"]
+				"@agnos-ui/check-replace-imports": ["error", "@agnos-ui/svelte"],
+				"@typescript-eslint/no-unused-vars": [
+					"error",
+					{"vars": "all", "args": "none", "ignoreRestSiblings": false, "varsIgnorePattern": "^\\$\\$(Props|Slots)$"}
+				]
 			}
 		}
 	]

--- a/svelte/demo/src/app/samples/alert/Generic.route.svelte
+++ b/svelte/demo/src/app/samples/alert/Generic.route.svelte
@@ -2,23 +2,15 @@
 	import {Alert} from '@agnos-ui/svelte/components/alert';
 	import {createWidgetsDefaultConfig} from '@agnos-ui/svelte/config';
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const widgetsConfig$ = createWidgetsDefaultConfig();
 	$widgetsConfig$ = {alert: {dismissible: false}};
 </script>
 
 <Alert type="primary">Simple primary alert</Alert>
-
 <Alert type="secondary">Simple secondary alert</Alert>
-
 <Alert type="success">Simple success alert</Alert>
-
 <Alert type="danger">Simple danger alert</Alert>
-
 <Alert type="warning">Simple warning alert</Alert>
-
 <Alert type="info">Simple info alert</Alert>
-
 <Alert type="light">Simple light alert</Alert>
-
 <Alert type="dark">Simple dark alert</Alert>

--- a/svelte/demo/src/app/samples/alert/Icon.route.svelte
+++ b/svelte/demo/src/app/samples/alert/Icon.route.svelte
@@ -3,7 +3,6 @@
 	import {createWidgetsDefaultConfig} from '@agnos-ui/svelte/config';
 	import Icon from './Icon.svelte';
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const widgetsConfig$ = createWidgetsDefaultConfig();
 	$widgetsConfig$.alert = {...$widgetsConfig$.alert, dismissible: false, className: 'd-flex align-items-center', slotStructure: Icon};
 </script>

--- a/svelte/demo/src/app/samples/alert/Icon.svelte
+++ b/svelte/demo/src/app/samples/alert/Icon.svelte
@@ -7,9 +7,8 @@
 	import biDashCircleFill from 'bootstrap-icons/icons/dash-circle-fill.svg?raw';
 	import biLightbulb from 'bootstrap-icons/icons/lightbulb.svg?raw';
 
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Props = AlertSlots['structure']; // eslint-disable-line @typescript-eslint/no-unused-vars
-	type $$Slots = AlertSlots; // eslint-disable-line @typescript-eslint/no-unused-vars
+	type $$Props = AlertSlots['structure'];
+	type $$Slots = AlertSlots;
 
 	export let state: $$Props['state'];
 	export let widget: $$Props['widget'];

--- a/svelte/demo/src/app/samples/modal/ComponentModal.svelte
+++ b/svelte/demo/src/app/samples/modal/ComponentModal.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
 	import type {ModalSlots} from '@agnos-ui/svelte/components/modal';
 	type ModalContent = {name: string};
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Props = ModalSlots<ModalContent>['default']; // eslint-disable-line @typescript-eslint/no-unused-vars
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Slots = ModalSlots<ModalContent>; // eslint-disable-line @typescript-eslint/no-unused-vars
+	type $$Props = ModalSlots<ModalContent>['default'];
+	type $$Slots = ModalSlots<ModalContent>;
 	export let widget: $$Props['widget'];
 	export let state: $$Props['state'];
 </script>

--- a/svelte/demo/src/app/samples/modal/StackModal.svelte
+++ b/svelte/demo/src/app/samples/modal/StackModal.svelte
@@ -3,10 +3,8 @@
 	import {openModal} from '@agnos-ui/svelte/components/modal';
 	import Self from './StackModal.svelte';
 
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Props = ModalSlots<void>['default']; // eslint-disable-line @typescript-eslint/no-unused-vars
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Slots = ModalSlots<void>; // eslint-disable-line @typescript-eslint/no-unused-vars
+	type $$Props = ModalSlots<void>['default'];
+	type $$Slots = ModalSlots<void>;
 	export let widget: $$Props['widget'];
 	export let state: $$Props['state'];
 </script>

--- a/svelte/demo/src/app/samples/pagination/CustomPages.svelte
+++ b/svelte/demo/src/app/samples/pagination/CustomPages.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
 	import type {PaginationSlots} from '@agnos-ui/svelte/components/pagination';
 
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Props = PaginationSlots['pages']; // eslint-disable-line @typescript-eslint/no-unused-vars
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Slots = PaginationSlots; // eslint-disable-line @typescript-eslint/no-unused-vars
+	type $$Props = PaginationSlots['pages'];
+	type $$Slots = PaginationSlots;
 
 	export let state: $$Props['state'];
 	export let widget: $$Props['widget'];

--- a/svelte/demo/src/app/samples/pagination/ReuseDefault.svelte
+++ b/svelte/demo/src/app/samples/pagination/ReuseDefault.svelte
@@ -2,10 +2,8 @@
 	import type {PaginationSlots} from '@agnos-ui/svelte/components/pagination';
 	import {Slot} from '@agnos-ui/svelte/slot';
 
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Props = PaginationSlots['pages']; // eslint-disable-line @typescript-eslint/no-unused-vars
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Slots = PaginationSlots; // eslint-disable-line @typescript-eslint/no-unused-vars
+	type $$Props = PaginationSlots['pages'];
+	type $$Slots = PaginationSlots;
 
 	export let state: $$Props['state'];
 	export let widget: $$Props['widget'];

--- a/svelte/demo/src/app/samples/progressbar/Coffee.svelte
+++ b/svelte/demo/src/app/samples/progressbar/Coffee.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import {type ProgressbarSlots} from '@agnos-ui/svelte/components/progressbar';
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Props = ProgressbarSlots['content']; // eslint-disable-line @typescript-eslint/no-unused-vars
-	type $$Slots = ProgressbarSlots; // eslint-disable-line @typescript-eslint/no-unused-vars
+	type $$Props = ProgressbarSlots['content'];
+	type $$Slots = ProgressbarSlots;
 
 	export let state: $$Props['state'];
 	import '@agnos-ui/common/samples/progressbar/custom.scss';

--- a/svelte/demo/src/app/samples/progressbar/Default.route.svelte
+++ b/svelte/demo/src/app/samples/progressbar/Default.route.svelte
@@ -2,7 +2,6 @@
 	import {Progressbar} from '@agnos-ui/svelte/components/progressbar';
 	import {createWidgetsDefaultConfig} from '@agnos-ui/svelte/config';
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const widgetsConfig$ = createWidgetsDefaultConfig();
 	$widgetsConfig$ = {progressbar: {slotDefault: (widget) => `${widget.state.percentage}%`}};
 </script>

--- a/svelte/demo/src/app/samples/rating/CustomStar.svelte
+++ b/svelte/demo/src/app/samples/rating/CustomStar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type {StarContext} from '@agnos-ui/svelte/components/rating';
-	type $$Props = StarContext; // eslint-disable-line @typescript-eslint/no-unused-vars
+	type $$Props = StarContext;
 
 	export let fill: number;
 </script>

--- a/svelte/demo/src/app/samples/slots/RatingReadonly.svelte
+++ b/svelte/demo/src/app/samples/slots/RatingReadonly.svelte
@@ -6,10 +6,8 @@
 </script>
 
 <script lang="ts">
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Props = Pick<Partial<Props>, 'rating' | 'maxRating' | 'className' | 'slotStar'>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
-	type $$Slots = Slots; // eslint-disable-line @typescript-eslint/no-unused-vars
+	type $$Props = Pick<Partial<Props>, 'rating' | 'maxRating' | 'className' | 'slotStar'>;
+	type $$Slots = Slots;
 
 	const widget = callWidgetFactory({
 		factory: createRating,


### PR DESCRIPTION
The comment lines to disable the no-unused-vars eslint rule were appearing in our Code samples.
To make the samples as readable as possible, I propose to move this disabling to the eslintrc.json config with a ignoreVars regex.