### PR TITLE
feat: refactor directives purposes

### DIFF
--- a/angular/lib/src/components/rating/rating.component.ts
+++ b/angular/lib/src/components/rating/rating.component.ts
@@ -1,5 +1,14 @@
 import type {AdaptSlotContentProps, RatingWidget, SlotContent, StarContext} from '@agnos-ui/angular-headless';
-import {BaseWidgetDirective, SlotDirective, auBooleanAttribute, auNumberAttribute, callWidgetFactory, createRating} from '@agnos-ui/angular-headless';
+import {
+	BaseWidgetDirective,
+	SlotDirective,
+	UseDirective,
+	auBooleanAttribute,
+	auNumberAttribute,
+	callWidgetFactory,
+	createRating,
+	useDirectiveForHost,
+} from '@agnos-ui/angular-headless';
 import type {AfterContentChecked} from '@angular/core';
 import {
 	ChangeDetectionStrategy,
@@ -28,35 +37,17 @@ export class RatingStarDirective {
 @Component({
 	selector: '[auRating]',
 	standalone: true,
-	imports: [SlotDirective],
+	imports: [UseDirective, SlotDirective],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,
 	host: {
-		class: 'd-inline-flex au-rating',
-		'[tabindex]': 'state().tabindex',
-		role: 'slider',
-		'aria-valuemin': '0',
-		'[attr.aria-valuemax]': 'state().maxRating',
-		'[attr.aria-valuenow]': 'state().visibleRating',
-		'[attr.aria-valuetext]': 'state().ariaValueText',
-		'[attr.aria-disabled]': 'state().disabled ? true : null',
-		'[attr.aria-readonly]': 'state().readonly ? true : null',
-		'[attr.aria-label]': 'state().ariaLabel || null',
-		'[attr.aria-labelledby]': 'state().ariaLabelledBy || null',
+		class: 'd-inline-flex',
 		'(blur)': 'onTouched()',
-		'(keydown)': '_widget.actions.handleKey($event)',
-		'(mouseleave)': '_widget.actions.leave()',
-		'[class]': 'state().className',
 	},
 	template: `
 		@for (item of state().stars; track trackByIndex(index); let index = $index) {
 			<span class="visually-hidden">({{ index < state().visibleRating ? '*' : ' ' }})</span>
-			<span
-				class="au-rating-star"
-				(mouseenter)="_widget.actions.hover(index + 1)"
-				(click)="_widget.actions.click(index + 1)"
-				[style.cursor]="state().interactive ? 'pointer' : 'default'"
-			>
+			<span [auUse]="_widget.directives.starDirective" [auUseParams]="{index}">
 				<ng-template [auSlot]="state().slotStar" [auSlotProps]="state().stars[index]"></ng-template>
 			</span>
 		}
@@ -74,6 +65,9 @@ export class RatingComponent extends BaseWidgetDirective<RatingWidget> implement
 				this.ratingChange.emit(rating);
 				this.onChange(rating);
 			},
+		},
+		afterInit: () => {
+			useDirectiveForHost(this._widget.directives.containerDirective);
 		},
 	});
 

--- a/core/package.json
+++ b/core/package.json
@@ -138,7 +138,8 @@
 	},
 	"peerDependencies": {
 		"@amadeus-it-group/tansu": "*",
-		"@floating-ui/dom": "*"
+		"@floating-ui/dom": "*",
+		"esm-env": "*"
 	},
 	"sideEffects": false,
 	"version": "0.0.0"

--- a/core/src/components/rating/rating.spec.ts
+++ b/core/src/components/rating/rating.spec.ts
@@ -2,9 +2,9 @@ import type {UnsubscribeFunction, WritableSignal} from '@amadeus-it-group/tansu'
 import {computed, writable} from '@amadeus-it-group/tansu';
 import type {MockInstance} from 'vitest';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
-import type {RatingWidget, RatingProps} from './rating';
-import {createRating, getRatingDefaultConfig} from './rating';
 import type {WidgetState} from '../../types';
+import type {RatingProps, RatingWidget} from './rating';
+import {createRating, getRatingDefaultConfig} from './rating';
 
 function keyboardEvent(key: string): KeyboardEvent {
 	return {
@@ -12,6 +12,14 @@ function keyboardEvent(key: string): KeyboardEvent {
 		preventDefault() {},
 		stopPropagation() {},
 	} as KeyboardEvent;
+}
+
+function getAttributes(node: HTMLElement) {
+	const attributes: Record<string, string> = {};
+	for (const {name, value} of [...node.attributes]) {
+		attributes[name] = value;
+	}
+	return attributes;
 }
 
 describe(`Rating`, () => {
@@ -623,6 +631,32 @@ describe(`Rating`, () => {
 			expect(state).toMatchObject({rating: 4});
 			defConfig.set({rating: 2}); // so changing the config continues to work
 			expect(state).toMatchObject({rating: 2});
+		});
+
+		test('containerDirective', () => {
+			const node = document.createElement('div');
+			const directiveInstance = rating.directives.containerDirective(node);
+			expect(getAttributes(node)).toStrictEqual({
+				'aria-valuemin': '0',
+				role: 'slider',
+				class: 'au-rating',
+				tabindex: '0',
+				'aria-valuemax': '10',
+				'aria-valuenow': '0',
+				'aria-valuetext': '0 out of 10',
+				'aria-label': 'Rating',
+			});
+			directiveInstance?.destroy?.();
+		});
+
+		test('starDirective', () => {
+			const node = document.createElement('div');
+			const directiveInstance = rating.directives.starDirective(node, {index: 1});
+			expect(getAttributes(node)).toStrictEqual({
+				class: 'au-rating-star',
+				style: 'cursor: pointer;',
+			});
+			directiveInstance?.destroy?.();
 		});
 	});
 

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -107,3 +107,6 @@ export interface WritableWithDefaultOptions<T> {
 }
 
 export type ConfigValidator<T extends object> = {[K in keyof T]?: WritableWithDefaultOptions<T[K]>};
+
+export type AttributeValue = string | number | boolean | undefined;
+export type StyleValue = string | undefined | null;

--- a/core/src/utils/internal/dom.spec.ts
+++ b/core/src/utils/internal/dom.spec.ts
@@ -1,5 +1,15 @@
 import {beforeEach, describe, expect, test} from 'vitest';
-import {computeCommonAncestor} from './dom';
+import {bindAttribute, bindClassName, bindStyle, computeCommonAncestor} from './dom';
+import {assign} from '../../../../common/utils';
+import {writable} from '@amadeus-it-group/tansu';
+
+function getAttributes(node: HTMLElement) {
+	const attributes: Record<string, string> = {};
+	for (const {name, value} of [...node.attributes]) {
+		attributes[name] = value;
+	}
+	return attributes;
+}
 
 describe('computeCommonAncestor', () => {
 	let parentElement: HTMLElement;
@@ -39,5 +49,105 @@ describe('computeCommonAncestor', () => {
 		expect(computeCommonAncestor([element4])).toBe(element4);
 		expect(computeCommonAncestor([element1, element4])).toBe(null);
 		expect(computeCommonAncestor([element4, element1])).toBe(null);
+	});
+
+	test('bindAttribute', () => {
+		const node = document.createElement('div');
+		const a$ = writable(<any>'a');
+
+		const unbind = bindAttribute(node, 'a', a$);
+
+		const expectedState: Record<string, string> = {a: 'a'};
+		expect(getAttributes(node)).toStrictEqual(expectedState);
+
+		a$.set('b');
+		expect(getAttributes(node)).toStrictEqual(assign(expectedState, {a: 'b'}));
+
+		a$.set('');
+		expect(getAttributes(node)).toStrictEqual(assign(expectedState, {a: ''}));
+
+		a$.set(true);
+		expect(getAttributes(node)).toStrictEqual(assign(expectedState, {a: ''}));
+
+		a$.set(false);
+		delete expectedState.a;
+		expect(getAttributes(node)).toStrictEqual(expectedState);
+
+		a$.set('a');
+		a$.set(undefined);
+		expect(getAttributes(node)).toStrictEqual(expectedState);
+
+		a$.set('a');
+		a$.set(null);
+		expect(getAttributes(node)).toStrictEqual(expectedState);
+
+		unbind();
+
+		a$.set('changes');
+		expect(getAttributes(node)).toStrictEqual(expectedState);
+	});
+
+	test('bindStyle', () => {
+		const node = document.createElement('div');
+		const a$ = writable(<any>'blue');
+
+		const unbind = bindStyle(node, 'color', a$);
+		console.log('(DEBUG)   node:', node);
+
+		const expectedState: Record<string, string> = {style: 'color: blue;'};
+		expect(getAttributes(node)).toStrictEqual(expectedState);
+
+		a$.set('red');
+		expect(getAttributes(node)).toStrictEqual(assign(expectedState, {style: 'color: red;'}));
+
+		a$.set('');
+		expect(getAttributes(node)).toStrictEqual(assign(expectedState, {style: ''}));
+
+		a$.set('a');
+		a$.set(false);
+		expect(getAttributes(node)).toStrictEqual(expectedState);
+
+		a$.set('a');
+		a$.set(undefined);
+		expect(getAttributes(node)).toStrictEqual(expectedState);
+
+		a$.set('a');
+		a$.set(null);
+		expect(getAttributes(node)).toStrictEqual(expectedState);
+
+		unbind();
+
+		a$.set('changes');
+		expect(getAttributes(node)).toStrictEqual(expectedState);
+	});
+
+	test('bindClassName', () => {
+		const node = document.createElement('div');
+		const a$ = writable(<boolean>true);
+		const b$ = writable(<boolean>false);
+
+		const unbindA = bindClassName(node, 'a', a$);
+		const unbindB = bindClassName(node, 'b', b$);
+
+		const expectedState: Record<string, string> = {class: 'a'};
+		expect(getAttributes(node)).toStrictEqual(expectedState);
+
+		a$.set(false);
+		expect(getAttributes(node)).toStrictEqual(assign(expectedState, {class: ''}));
+
+		a$.set(true);
+		b$.set(true);
+		expect(getAttributes(node)).toStrictEqual(assign(expectedState, {class: 'a b'}));
+
+		a$.set(false);
+		expect(getAttributes(node)).toStrictEqual(assign(expectedState, {class: 'b'}));
+
+		a$.set(true);
+		expect(getAttributes(node)).toStrictEqual(assign(expectedState, {class: 'b a'}));
+
+		unbindA();
+		unbindB();
+
+		expect(getAttributes(node)).toStrictEqual(assign(expectedState, {class: ''}));
 	});
 });

--- a/core/src/utils/internal/dom.ts
+++ b/core/src/utils/internal/dom.ts
@@ -1,3 +1,6 @@
+import type {ReadableSignal} from '@amadeus-it-group/tansu';
+import type {AttributeValue, StyleValue} from '../../types';
+
 /**
  * Returns the common ancestor of the provided DOM elements.
  * @param elements - array of DOM elements
@@ -95,3 +98,88 @@ let idCount = 0;
  * @returns The generated ID.
  */
 export const generateId = () => `auId-${idCount++}`;
+const notEmpty = (value: any) => value != null && value !== false;
+
+function classNamesSubscribe(node: HTMLElement, classNames$: ReadableSignal<string>) {
+	let currentClassNames = new Set<string>();
+
+	return classNames$.subscribe((newClassName: AttributeValue) => {
+		const classNames = new Set(`${newClassName ?? ''}`.split(' '));
+		classNames.delete('');
+		const classList = node.classList;
+		for (const className of currentClassNames) {
+			if (!classNames.has(className)) {
+				classList.remove(className);
+			}
+		}
+		classList.add(...classNames);
+		currentClassNames = classNames;
+	});
+}
+
+function attributeSubscribe(node: HTMLElement, attributeName: string, value$: ReadableSignal<AttributeValue>) {
+	return value$.subscribe((value) => {
+		if (notEmpty(value)) {
+			node.setAttribute(attributeName, '' + (value === true ? '' : value));
+		} else {
+			node.removeAttribute(attributeName);
+		}
+	});
+}
+
+/**
+ * Binds a value from a `ReadableSignal` to the specified attribute of an HTML element.
+ * When the value emitted by the signal changes, it updates the attribute accordingly.
+ * If the value is null, undefined or `false`, the attribute is removed from the element.
+ * An empty string or `true` will result in an attribute with an empty value
+ *
+ * @param node The HTML element to bind the attribute to.
+ * @param attributeName The name of the attribute to bind.
+ * @param value$ The `ReadableSignal` representing the value to bind to the attribute.
+ *
+ * @returns unsubscription method to remove the binding
+ */
+export function bindAttribute(node: HTMLElement, attributeName: string, value$: ReadableSignal<AttributeValue>) {
+	const isClass = attributeName === 'class';
+	return isClass
+		? classNamesSubscribe(node, value$ as ReadableSignal<string>) // Specific case for classnames
+		: attributeSubscribe(node, attributeName, value$);
+}
+
+/**
+ * Binds a value from a `ReadableSignal` to the specified CSS style property of an HTML element.
+ * When the value emitted by the signal changes, it updates the style property accordingly.
+ * If the value is  null, undefined or an empty string, the style property is cleared.
+ *
+ * @param node The HTML element to bind the style property to.
+ * @param styleName The name of the CSS style property to bind.
+ * @param value$ The `ReadableSignal` representing the value to bind to the style property.
+ *
+ * @returns unsubscription method to remove the binding
+ */
+export function bindStyle(node: HTMLElement, styleName: string, value$: ReadableSignal<StyleValue>) {
+	return value$.subscribe((value) => {
+		const style = node.style;
+		style[styleName as any] = '' + (notEmpty(value) ? value : '');
+	});
+}
+
+/**
+ * Binds a `ReadableSignal` of boolean to the specified className of an HTML element.
+ * The className is added when the value is true, removed otherwise
+ *
+ * @param node - The HTML element to bind the style property to.
+ * @param className - The className to bind.
+ * @param value$ - The `ReadableSignal` representing the value to bind to the className.
+ *
+ * @returns unsubscription method to remove the binding
+ */
+export function bindClassName(node: HTMLElement, className: string, value$: ReadableSignal<boolean>) {
+	const unsubscribe = value$.subscribe((isPresent) => {
+		node.classList.toggle(className, isPresent);
+	});
+	return () => {
+		unsubscribe();
+		node.classList.remove(className);
+	};
+}

--- a/e2e/rating/rating.e2e-spec.ts
+++ b/e2e/rating/rating.e2e-spec.ts
@@ -22,7 +22,7 @@ test.describe.parallel(`Rating tests`, () => {
 
 		await test.step('click interactions', async () => {
 			let expectedState: State = {
-				rootClasses: ['d-inline-flex', 'au-rating'],
+				rootClasses: ['au-rating', 'd-inline-flex'],
 				min: '0',
 				max: '10',
 				value: '3',
@@ -74,7 +74,7 @@ test.describe.parallel(`Rating tests`, () => {
 				await expect
 					.poll(() => ratingPO.state())
 					.toEqual({
-						rootClasses: ['d-inline-flex', 'au-rating'],
+						rootClasses: ['au-rating', 'd-inline-flex'],
 						min: '0',
 						max: '10',
 						value: value.toString(),
@@ -116,7 +116,7 @@ test.describe.parallel(`Rating tests`, () => {
 		expectedClasses.length = 5;
 		expectedClasses.fill(['au-rating-star']);
 		const expectedState: State = {
-			rootClasses: ['d-inline-flex', 'au-rating', 'rating-readonly'],
+			rootClasses: ['au-rating', 'd-inline-flex', 'rating-readonly'],
 			min: '0',
 			max: '5',
 			value: '3.64',
@@ -175,7 +175,7 @@ test.describe.parallel(`Rating tests`, () => {
 		await ratingPO.locatorRoot.waitFor();
 
 		let expectedState: State = {
-			rootClasses: ['d-inline-flex', 'au-rating'],
+			rootClasses: ['au-rating', 'd-inline-flex'],
 			min: '0',
 			max: '10',
 			value: '3',

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,11 @@
 				"@angular-eslint/template-parser": "^17.3.0",
 				"@angular/cli": "~17.3.0",
 				"@angular/compiler-cli": "~17.3.0",
+				"autoprefixer": "^10.4.18",
+				"daisyui": "^4.7.3",
+				"postcss": "^8.4.36",
 				"sirv-cli": "^2.0.2",
+				"tailwindcss": "^3.4.1",
 				"typescript": "~5.4.2"
 			}
 		},

--- a/page-objects/lib/rating.po.ts
+++ b/page-objects/lib/rating.po.ts
@@ -20,8 +20,6 @@ export class RatingPO extends BasePO {
 		return this.locatorRoot.locator(this.selectors.star).nth(index);
 	}
 
-	// TODO to be pushed to the test itself
-	// We already discuss with Guillaume Saas not to put this in the basic PO which should only return locator basically
 	async state() {
 		return await this.locatorRoot.evaluate((rootNode: HTMLElement, selectors) => {
 			const starsElements = [...rootNode.querySelectorAll(selectors.star)] as HTMLSpanElement[];
@@ -33,7 +31,7 @@ export class RatingPO extends BasePO {
 			}
 
 			return {
-				rootClasses: rootNode.className.trim().split(' '),
+				rootClasses: rootNode.className.trim().split(' ').sort(),
 				value: rootNode.getAttribute('aria-valuenow'),
 				min: rootNode.getAttribute('aria-valuemin'),
 				max: rootNode.getAttribute('aria-valuemax'),

--- a/svelte/lib/src/components/rating/Rating.svelte
+++ b/svelte/lib/src/components/rating/Rating.svelte
@@ -1,8 +1,8 @@
 <script lang="ts" context="module">
 	import type {RatingProps as Props, RatingSlots as Slots} from '@agnos-ui/svelte-headless/components/rating';
 	import {createRating} from '@agnos-ui/svelte-headless/components/rating';
-	import {Slot} from '@agnos-ui/svelte-headless/slot';
 	import {callWidgetFactory} from '@agnos-ui/svelte-headless/config';
+	import {Slot} from '@agnos-ui/svelte-headless/slot';
 </script>
 
 <script lang="ts">
@@ -26,52 +26,18 @@
 	});
 
 	const {
-		stores: {
-			tabindex$,
-			maxRating$,
-			visibleRating$,
-			ariaValueText$,
-			readonly$,
-			disabled$,
-			interactive$,
-			stars$,
-			className$,
-			slotStar$,
-			ariaLabel$,
-			ariaLabelledBy$,
-		},
-		actions: {handleKey, leave, hover, click},
+		stores: {visibleRating$, stars$, slotStar$},
+		directives: {containerDirective, starDirective},
 		patchChangedProps,
 	} = widget;
 	$: patchChangedProps($$props);
 </script>
 
-<div
-	role="slider"
-	class="d-inline-flex au-rating {$className$}"
-	tabindex={$tabindex$}
-	aria-valuemin={0}
-	aria-valuemax={$maxRating$}
-	aria-valuenow={$visibleRating$}
-	aria-valuetext={$ariaValueText$}
-	aria-readonly={$readonly$ || undefined}
-	aria-disabled={$disabled$ || undefined}
-	aria-label={$ariaLabel$ || undefined}
-	aria-labelledby={$ariaLabelledBy$ || undefined}
-	on:keydown={handleKey}
-	on:mouseleave={leave}
->
+<div use:containerDirective class="d-inline-flex">
 	<!-- on:blur={onTouched} ?? -->
 	{#each $stars$ as { fill, index }}
 		<span class="visually-hidden">({index < $visibleRating$ ? '*' : ' '})</span>
-		<!-- svelte-ignore a11y-click-events-have-key-events -->
-		<!-- svelte-ignore a11y-no-static-element-interactions -->
-		<span
-			class="au-rating-star"
-			style:cursor={$interactive$ ? 'pointer' : 'default'}
-			on:mouseenter={() => hover(index + 1)}
-			on:click={() => click(index + 1)}
-		>
+		<span use:starDirective={{index}}>
 			<Slot slotContent={$slotStar$} props={{fill, index}} let:component let:props>
 				<svelte:fragment slot="slot" let:props><slot name="star" {...props} /></svelte:fragment>
 				<svelte:component this={component} {...props} />

--- a/viteAlias.ts
+++ b/viteAlias.ts
@@ -2,10 +2,12 @@ import path from 'path';
 
 export const alias: Record<string, string> = {
 	'@agnos-ui/core': path.join(__dirname, './core/src'),
+	'@agnos-ui/react-headless/utils': path.join(__dirname, './react/headless/src/generated/utils'),
 	'@agnos-ui/react-headless/services': path.join(__dirname, './react/headless/src/generated/services'),
 	'@agnos-ui/react-headless': path.join(__dirname, './react/headless/src'),
 	'@agnos-ui/react/components': path.join(__dirname, './react/lib/src/components'),
 	'@agnos-ui/react': path.join(__dirname, './react/lib/src/generated'),
+	'@agnos-ui/svelte-headless/utils': path.join(__dirname, './svelte/headless/src/generated/utils'),
 	'@agnos-ui/svelte-headless/services': path.join(__dirname, './svelte/headless/src/generated/services'),
 	'@agnos-ui/svelte-headless': path.join(__dirname, './svelte/headless/src'),
 	'@agnos-ui/svelte/components': path.join(__dirname, './svelte/lib/src/components'),


### PR DESCRIPTION
fix #537

This is a POC to see what's happen if we delegate more works on directives:

- increase the common code
- decrease the code duplication between frameworks
- ease the headless usage

On the other hand:

-  bypass the framework templating  engine