### PR TITLE
test; introduce npm run tdd:debug

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -49,6 +49,7 @@
 		"test": "vitest run",
 		"tdd": "vitest",
 		"tdd:ui": "vitest --ui",
+		"tdd:debug": "vitest --no-browser.headless",
 		"test:coverage": "wireit"
 	},
 	"wireit": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"check": "wireit",
 		"tdd": "node scripts/run.js tdd",
 		"tdd:ui": "node scripts/run.js tdd:ui",
+		"tdd:debug": "node scripts/run.js tdd:debug",
 		"test:coverage": "node scripts/run.js test:coverage",
 		"test": "node scripts/run.js test serial",
 		"format:fix": "prettier . \"**/*.svelte\" --write --cache .",


### PR DESCRIPTION
To run the unit test in headful mode.

I had to search a little how to do it, because of the issue : https://github.com/vitest-dev/vitest/issues/5055, to use the --no-browser.headless command line. Maybe we will adapt the command once the issue is fixed.

