### PR TITLE
Workaround for SSR svelte issue with slots

### DIFF
--- a/eslint-plugin/src/svelte-check-slots.ts
+++ b/eslint-plugin/src/svelte-check-slots.ts
@@ -105,7 +105,7 @@ const extractSlotName = (node: SvelteAST.SvelteElement) => {
 
 const buildNodeText = (slotAttributes: string, slotName: string, slotsList: ReturnType<typeof extractExpectedSlotsList>) => {
 	const slotNameArg = slotName === 'default' ? '' : ` name=${JSON.stringify(slotName)}`;
-	let output = `<Slot${slotAttributes} let:component let:props>\n\t<slot slot="slot"${slotNameArg} let:props {...props} />\n`;
+	let output = `<Slot${slotAttributes} let:component let:props>\n\t<svelte:fragment slot="slot" let:props><slot${slotNameArg} {...props} /></svelte:fragment>\n`;
 	if (slotsList.length > 0) {
 		output += `\t<svelte:component this={component} {...props}>\n`;
 		for (const {slot, params} of slotsList) {
@@ -119,7 +119,7 @@ const buildNodeText = (slotAttributes: string, slotName: string, slotsList: Retu
 				output += `\t\t<svelte:fragment${defParam}><slot${useParam} /></svelte:fragment>\n`;
 			} else {
 				const strSlot = JSON.stringify(slot);
-				output += `\t\t<slot name=${strSlot} slot=${strSlot}${defParam}${useParam} />\n`;
+				output += `\t\t<svelte:fragment slot=${strSlot}${defParam}><slot name=${strSlot}${useParam} /></svelte:fragment>\n`;
 			}
 		}
 		output += `\t</svelte:component>\n`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10419,7 +10419,8 @@
 		"node_modules/esm-env": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
-			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA=="
+			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
+			"dev": true
 		},
 		"node_modules/espree": {
 			"version": "9.6.1",
@@ -21533,8 +21534,7 @@
 		"svelte/headless": {
 			"name": "@agnos-ui/svelte-headless",
 			"dependencies": {
-				"@agnos-ui/core": "",
-				"esm-env": "^1.0.0"
+				"@agnos-ui/core": ""
 			},
 			"devDependencies": {
 				"@sveltejs/package": "^2.3.0"

--- a/svelte/demo/src/app/samples/alert/Icon.svelte
+++ b/svelte/demo/src/app/samples/alert/Icon.svelte
@@ -25,10 +25,10 @@
 <span class="d-flex me-2">{@html typeIcon[state.type]}</span>
 <div class="alert-body">
 	<Slot slotContent={state.slotDefault} props={{widget, state}} let:component let:props>
-		<slot slot="slot" let:props {...props} />
+		<svelte:fragment slot="slot" let:props><slot {...props} /></svelte:fragment>
 		<svelte:component this={component} {...props}>
 			<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-			<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+			<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 		</svelte:component>
 	</Slot>
 </div>

--- a/svelte/demo/src/app/samples/pagination/ReuseDefault.svelte
+++ b/svelte/demo/src/app/samples/pagination/ReuseDefault.svelte
@@ -24,16 +24,18 @@
 			<!-- svelte-ignore a11y-invalid-attribute -->
 			<a class="page-link au-ellipsis" tabindex="-1" aria-disabled="true" on:click|preventDefault|stopPropagation href="#">
 				<Slot slotContent={$slotEllipsis$} props={{state, widget}} let:component let:props>
-					<slot slot="slot" name="ellipsis" let:props {...props} />
+					<svelte:fragment slot="slot" let:props><slot name="ellipsis" {...props} /></svelte:fragment>
 					<svelte:component this={component} {...props}>
-						<slot name="ellipsis" slot="ellipsis" let:state let:widget {state} {widget} />
-						<slot name="first" slot="first" let:state let:widget {state} {widget} />
-						<slot name="last" slot="last" let:state let:widget {state} {widget} />
-						<slot name="next" slot="next" let:state let:widget {state} {widget} />
-						<slot name="numberLabel" slot="numberLabel" let:displayedPage let:state let:widget {displayedPage} {state} {widget} />
-						<slot name="pages" slot="pages" let:state let:widget {state} {widget} />
-						<slot name="previous" slot="previous" let:state let:widget {state} {widget} />
-						<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+						<svelte:fragment slot="ellipsis" let:state let:widget><slot name="ellipsis" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="first" let:state let:widget><slot name="first" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="last" let:state let:widget><slot name="last" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="next" let:state let:widget><slot name="next" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="numberLabel" let:displayedPage let:state let:widget
+							><slot name="numberLabel" {displayedPage} {state} {widget} /></svelte:fragment
+						>
+						<svelte:fragment slot="pages" let:state let:widget><slot name="pages" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="previous" let:state let:widget><slot name="previous" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 					</svelte:component>
 				</Slot>
 			</a>
@@ -48,16 +50,18 @@
 				aria-disabled={state.disabled ? 'true' : null}
 			>
 				<Slot slotContent={$slotNumberLabel$} props={{state, widget, displayedPage: page}} let:component let:props>
-					<slot slot="slot" name="numberLabel" let:props {...props} />
+					<svelte:fragment slot="slot" let:props><slot name="numberLabel" {...props} /></svelte:fragment>
 					<svelte:component this={component} {...props}>
-						<slot name="ellipsis" slot="ellipsis" let:state let:widget {state} {widget} />
-						<slot name="first" slot="first" let:state let:widget {state} {widget} />
-						<slot name="last" slot="last" let:state let:widget {state} {widget} />
-						<slot name="next" slot="next" let:state let:widget {state} {widget} />
-						<slot name="numberLabel" slot="numberLabel" let:displayedPage let:state let:widget {displayedPage} {state} {widget} />
-						<slot name="pages" slot="pages" let:state let:widget {state} {widget} />
-						<slot name="previous" slot="previous" let:state let:widget {state} {widget} />
-						<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+						<svelte:fragment slot="ellipsis" let:state let:widget><slot name="ellipsis" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="first" let:state let:widget><slot name="first" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="last" let:state let:widget><slot name="last" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="next" let:state let:widget><slot name="next" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="numberLabel" let:displayedPage let:state let:widget
+							><slot name="numberLabel" {displayedPage} {state} {widget} /></svelte:fragment
+						>
+						<svelte:fragment slot="pages" let:state let:widget><slot name="pages" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="previous" let:state let:widget><slot name="previous" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 					</svelte:component>
 				</Slot>
 				{#if $page$ === page}

--- a/svelte/demo/src/app/samples/slots/RatingReadonly.svelte
+++ b/svelte/demo/src/app/samples/slots/RatingReadonly.svelte
@@ -37,7 +37,7 @@
                 The api is currently a bit tricky, until Svelte 5 arrives with snippets.
             -->
 			<Slot slotContent={$slotStar$} props={{fill, index}} let:component let:props>
-				<slot slot="slot" name="star" let:props {...props} />
+				<svelte:fragment slot="slot" let:props><slot name="star" {...props} /></svelte:fragment>
 				<svelte:component this={component} {...props} />
 			</Slot>
 		</span>

--- a/svelte/demo/src/app/samples/toast/Action.svelte
+++ b/svelte/demo/src/app/samples/toast/Action.svelte
@@ -19,11 +19,11 @@
 	<div class="d-flex align-items-center flex-grow-1 toast-body">
 		<span class="d-flex me-2">{@html biCheckCircleFill}</span>
 		<Slot slotContent={state.slotDefault} props={{widget, state}} let:component let:props>
-			<slot slot="slot" let:props {...props} />
+			<svelte:fragment slot="slot" let:props><slot {...props} /></svelte:fragment>
 			<svelte:component this={component} {...props}>
 				<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-				<slot name="header" slot="header" let:state let:widget {state} {widget} />
-				<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+				<svelte:fragment slot="header" let:state let:widget><slot name="header" {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 			</svelte:component>
 		</Slot>
 		<button type="button" class="btn btn-sm ms-auto text-bg-success" on:click={actionDemo}>

--- a/svelte/headless/package.json
+++ b/svelte/headless/package.json
@@ -121,8 +121,7 @@
 		}
 	},
 	"dependencies": {
-		"@agnos-ui/core": "",
-		"esm-env": "^1.0.0"
+		"@agnos-ui/core": ""
 	},
 	"peerDependencies": {
 		"@amadeus-it-group/tansu": "*",

--- a/svelte/headless/src/Slot.svelte
+++ b/svelte/headless/src/Slot.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-	import {BROWSER} from 'esm-env';
 	import type {SlotContent, SlotSvelteComponent} from './types';
-	import {useSvelteSlot} from './types';
 	import {isSvelteComponent} from './utils/widget';
+	import {useSvelteSlot} from './types';
 	type Props = $$Generic<object>; // eslint-disable-line no-undef
 	// cf https://github.com/ota-meshi/eslint-plugin-svelte/issues/348
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -12,13 +11,6 @@
 	};
 	export let slotContent: SlotContent<Props> = null;
 	export let props: Props;
-
-	// Workaround for a svelte issue that prevents code generation for SSR/slot
-	// To be removed when https://github.com/sveltejs/svelte/issues/9137 is fixed
-	if (!BROWSER) {
-		// @ts-expect-error Setting the global variable `props`, which is not defined in the SSR Svelte-kit compilation
-		globalThis['props'] = props;
-	}
 </script>
 
 {#if slotContent === useSvelteSlot}

--- a/svelte/lib/src/components/accordion/Item.svelte
+++ b/svelte/lib/src/components/accordion/Item.svelte
@@ -49,11 +49,11 @@
 
 <div class="accordion-item {$itemClass$}" id={$itemId$} use:accordionItemDirective>
 	<Slot slotContent={$slotItemStructure$} props={slotContext} let:component let:props>
-		<slot slot="slot" name="itemStructure" let:props {...props} />
+		<svelte:fragment slot="slot" let:props><slot name="itemStructure" {...props} /></svelte:fragment>
 		<svelte:component this={component} {...props}>
-			<slot name="itemBody" slot="itemBody" let:state let:widget {state} {widget} />
-			<slot name="itemHeader" slot="itemHeader" let:state let:widget {state} {widget} />
-			<slot name="itemStructure" slot="itemStructure" let:state let:widget {state} {widget} />
+			<svelte:fragment slot="itemBody" let:state let:widget><slot name="itemBody" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="itemHeader" let:state let:widget><slot name="itemHeader" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="itemStructure" let:state let:widget><slot name="itemStructure" {state} {widget} /></svelte:fragment>
 		</svelte:component>
 	</Slot>
 </div>

--- a/svelte/lib/src/components/accordion/ItemDefaultStructure.svelte
+++ b/svelte/lib/src/components/accordion/ItemDefaultStructure.svelte
@@ -29,11 +29,11 @@
 		aria-expanded={state.itemVisible}
 	>
 		<Slot slotContent={state.slotItemHeader} props={slotContext} let:component let:props>
-			<slot slot="slot" name="itemHeader" let:props {...props} />
+			<svelte:fragment slot="slot" let:props><slot name="itemHeader" {...props} /></svelte:fragment>
 			<svelte:component this={component} {...props}>
-				<slot name="itemBody" slot="itemBody" let:state let:widget {state} {widget} />
-				<slot name="itemHeader" slot="itemHeader" let:state let:widget {state} {widget} />
-				<slot name="itemStructure" slot="itemStructure" let:state let:widget {state} {widget} />
+				<svelte:fragment slot="itemBody" let:state let:widget><slot name="itemBody" {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="itemHeader" let:state let:widget><slot name="itemHeader" {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="itemStructure" let:state let:widget><slot name="itemStructure" {state} {widget} /></svelte:fragment>
 			</svelte:component>
 		</Slot>
 	</button>
@@ -42,11 +42,11 @@
 	<div class="accordion-collapse {state.itemBodyContainerClass}" use:widget.directives.collapseDirective id={collapseId} aria-labelledby={toggleId}>
 		<div class="accordion-body {state.itemBodyClass}">
 			<Slot slotContent={state.slotItemBody} props={slotContext} let:component let:props>
-				<slot slot="slot" name="itemBody" let:props {...props} />
+				<svelte:fragment slot="slot" let:props><slot name="itemBody" {...props} /></svelte:fragment>
 				<svelte:component this={component} {...props}>
-					<slot name="itemBody" slot="itemBody" let:state let:widget {state} {widget} />
-					<slot name="itemHeader" slot="itemHeader" let:state let:widget {state} {widget} />
-					<slot name="itemStructure" slot="itemStructure" let:state let:widget {state} {widget} />
+					<svelte:fragment slot="itemBody" let:state let:widget><slot name="itemBody" {state} {widget} /></svelte:fragment>
+					<svelte:fragment slot="itemHeader" let:state let:widget><slot name="itemHeader" {state} {widget} /></svelte:fragment>
+					<svelte:fragment slot="itemStructure" let:state let:widget><slot name="itemStructure" {state} {widget} /></svelte:fragment>
 				</svelte:component>
 			</Slot>
 		</div>

--- a/svelte/lib/src/components/alert/Alert.svelte
+++ b/svelte/lib/src/components/alert/Alert.svelte
@@ -46,10 +46,10 @@
 		use:transitionDirective
 	>
 		<Slot slotContent={$slotStructure$} props={slotContext} let:component let:props>
-			<slot slot="slot" name="structure" let:props {...props} />
+			<svelte:fragment slot="slot" let:props><slot name="structure" {...props} /></svelte:fragment>
 			<svelte:component this={component} {...props}>
 				<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-				<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+				<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 			</svelte:component>
 		</Slot>
 	</div>

--- a/svelte/lib/src/components/alert/AlertDefaultStructure.svelte
+++ b/svelte/lib/src/components/alert/AlertDefaultStructure.svelte
@@ -15,10 +15,10 @@
 
 <div class="alert-body">
 	<Slot slotContent={state.slotDefault} props={slotContext} let:component let:props>
-		<slot slot="slot" let:props {...props} />
+		<svelte:fragment slot="slot" let:props><slot {...props} /></svelte:fragment>
 		<svelte:component this={component} {...props}>
 			<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-			<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+			<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 		</svelte:component>
 	</Slot>
 </div>

--- a/svelte/lib/src/components/modal/Modal.svelte
+++ b/svelte/lib/src/components/modal/Modal.svelte
@@ -58,13 +58,13 @@
 		<div class="modal-dialog">
 			<div class="modal-content">
 				<Slot slotContent={$slotStructure$} props={slotContext} let:component let:props>
-					<slot slot="slot" name="structure" let:props {...props} />
+					<svelte:fragment slot="slot" let:props><slot name="structure" {...props} /></svelte:fragment>
 					<svelte:component this={component} {...props}>
 						<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-						<slot name="footer" slot="footer" let:state let:widget {state} {widget} />
-						<slot name="header" slot="header" let:state let:widget {state} {widget} />
-						<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
-						<slot name="title" slot="title" let:state let:widget {state} {widget} />
+						<svelte:fragment slot="footer" let:state let:widget><slot name="footer" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="header" let:state let:widget><slot name="header" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="title" let:state let:widget><slot name="title" {state} {widget} /></svelte:fragment>
 					</svelte:component>
 				</Slot>
 			</div>

--- a/svelte/lib/src/components/modal/ModalDefaultHeader.svelte
+++ b/svelte/lib/src/components/modal/ModalDefaultHeader.svelte
@@ -14,13 +14,13 @@
 
 <h5 class="modal-title">
 	<Slot slotContent={state.slotTitle} props={slotContext} let:component let:props>
-		<slot slot="slot" name="title" let:props {...props} />
+		<svelte:fragment slot="slot" let:props><slot name="title" {...props} /></svelte:fragment>
 		<svelte:component this={component} {...props}>
 			<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-			<slot name="footer" slot="footer" let:state let:widget {state} {widget} />
-			<slot name="header" slot="header" let:state let:widget {state} {widget} />
-			<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
-			<slot name="title" slot="title" let:state let:widget {state} {widget} />
+			<svelte:fragment slot="footer" let:state let:widget><slot name="footer" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="header" let:state let:widget><slot name="header" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="title" let:state let:widget><slot name="title" {state} {widget} /></svelte:fragment>
 		</svelte:component>
 	</Slot>
 </h5>

--- a/svelte/lib/src/components/modal/ModalDefaultStructure.svelte
+++ b/svelte/lib/src/components/modal/ModalDefaultStructure.svelte
@@ -15,13 +15,13 @@
 {#if state.slotTitle}
 	<div class="modal-header">
 		<Slot slotContent={state.slotHeader} props={slotContext} let:component let:props>
-			<slot slot="slot" name="header" let:props {...props} />
+			<svelte:fragment slot="slot" let:props><slot name="header" {...props} /></svelte:fragment>
 			<svelte:component this={component} {...props}>
 				<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-				<slot name="footer" slot="footer" let:state let:widget {state} {widget} />
-				<slot name="header" slot="header" let:state let:widget {state} {widget} />
-				<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
-				<slot name="title" slot="title" let:state let:widget {state} {widget} />
+				<svelte:fragment slot="footer" let:state let:widget><slot name="footer" {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="header" let:state let:widget><slot name="header" {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="title" let:state let:widget><slot name="title" {state} {widget} /></svelte:fragment>
 			</svelte:component>
 		</Slot>
 	</div>
@@ -29,26 +29,26 @@
 
 <div class="modal-body">
 	<Slot slotContent={state.slotDefault} props={slotContext} let:component let:props>
-		<slot slot="slot" let:props {...props} />
+		<svelte:fragment slot="slot" let:props><slot {...props} /></svelte:fragment>
 		<svelte:component this={component} {...props}>
 			<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-			<slot name="footer" slot="footer" let:state let:widget {state} {widget} />
-			<slot name="header" slot="header" let:state let:widget {state} {widget} />
-			<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
-			<slot name="title" slot="title" let:state let:widget {state} {widget} />
+			<svelte:fragment slot="footer" let:state let:widget><slot name="footer" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="header" let:state let:widget><slot name="header" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="title" let:state let:widget><slot name="title" {state} {widget} /></svelte:fragment>
 		</svelte:component>
 	</Slot>
 </div>
 {#if state.slotFooter}
 	<div class="modal-footer">
 		<Slot slotContent={state.slotFooter} props={slotContext} let:component let:props>
-			<slot slot="slot" name="footer" let:props {...props} />
+			<svelte:fragment slot="slot" let:props><slot name="footer" {...props} /></svelte:fragment>
 			<svelte:component this={component} {...props}>
 				<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-				<slot name="footer" slot="footer" let:state let:widget {state} {widget} />
-				<slot name="header" slot="header" let:state let:widget {state} {widget} />
-				<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
-				<slot name="title" slot="title" let:state let:widget {state} {widget} />
+				<svelte:fragment slot="footer" let:state let:widget><slot name="footer" {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="header" let:state let:widget><slot name="header" {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="title" let:state let:widget><slot name="title" {state} {widget} /></svelte:fragment>
 			</svelte:component>
 		</Slot>
 	</div>

--- a/svelte/lib/src/components/pagination/Pagination.svelte
+++ b/svelte/lib/src/components/pagination/Pagination.svelte
@@ -52,16 +52,18 @@
 <!-- Should we put nav here ? how to custom the class of ul in this case ?-->
 <nav aria-label={$ariaLabel$}>
 	<Slot slotContent={$slotStructure$} props={slotContext} let:component let:props>
-		<slot slot="slot" name="structure" let:props {...props} />
+		<svelte:fragment slot="slot" let:props><slot name="structure" {...props} /></svelte:fragment>
 		<svelte:component this={component} {...props}>
-			<slot name="ellipsis" slot="ellipsis" let:state let:widget {state} {widget} />
-			<slot name="first" slot="first" let:state let:widget {state} {widget} />
-			<slot name="last" slot="last" let:state let:widget {state} {widget} />
-			<slot name="next" slot="next" let:state let:widget {state} {widget} />
-			<slot name="numberLabel" slot="numberLabel" let:displayedPage let:state let:widget {displayedPage} {state} {widget} />
-			<slot name="pages" slot="pages" let:state let:widget {state} {widget} />
-			<slot name="previous" slot="previous" let:state let:widget {state} {widget} />
-			<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+			<svelte:fragment slot="ellipsis" let:state let:widget><slot name="ellipsis" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="first" let:state let:widget><slot name="first" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="last" let:state let:widget><slot name="last" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="next" let:state let:widget><slot name="next" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="numberLabel" let:displayedPage let:state let:widget
+				><slot name="numberLabel" {displayedPage} {state} {widget} /></svelte:fragment
+			>
+			<svelte:fragment slot="pages" let:state let:widget><slot name="pages" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="previous" let:state let:widget><slot name="previous" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 		</svelte:component>
 	</Slot>
 </nav>

--- a/svelte/lib/src/components/pagination/PaginationDefaultPages.svelte
+++ b/svelte/lib/src/components/pagination/PaginationDefaultPages.svelte
@@ -20,16 +20,18 @@
 		{#if page === -1}
 			<div class="page-link au-ellipsis" aria-hidden="true">
 				<Slot slotContent={state.slotEllipsis} props={{state, widget}} let:component let:props>
-					<slot slot="slot" name="ellipsis" let:props {...props} />
+					<svelte:fragment slot="slot" let:props><slot name="ellipsis" {...props} /></svelte:fragment>
 					<svelte:component this={component} {...props}>
-						<slot name="ellipsis" slot="ellipsis" let:state let:widget {state} {widget} />
-						<slot name="first" slot="first" let:state let:widget {state} {widget} />
-						<slot name="last" slot="last" let:state let:widget {state} {widget} />
-						<slot name="next" slot="next" let:state let:widget {state} {widget} />
-						<slot name="numberLabel" slot="numberLabel" let:displayedPage let:state let:widget {displayedPage} {state} {widget} />
-						<slot name="pages" slot="pages" let:state let:widget {state} {widget} />
-						<slot name="previous" slot="previous" let:state let:widget {state} {widget} />
-						<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+						<svelte:fragment slot="ellipsis" let:state let:widget><slot name="ellipsis" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="first" let:state let:widget><slot name="first" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="last" let:state let:widget><slot name="last" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="next" let:state let:widget><slot name="next" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="numberLabel" let:displayedPage let:state let:widget
+							><slot name="numberLabel" {displayedPage} {state} {widget} /></svelte:fragment
+						>
+						<svelte:fragment slot="pages" let:state let:widget><slot name="pages" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="previous" let:state let:widget><slot name="previous" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 					</svelte:component>
 				</Slot>
 			</div>
@@ -48,17 +50,21 @@
 					props={{state, widget, displayedPage: page}}
 					let:component
 					let:props
-					><slot slot="slot" name="numberLabel" let:props {...props} /><svelte:component this={component} {...props}>
-						<slot name="ellipsis" slot="ellipsis" let:state let:widget {state} {widget} />
-						<slot name="first" slot="first" let:state let:widget {state} {widget} />
-						<slot name="last" slot="last" let:state let:widget {state} {widget} />
-						<slot name="next" slot="next" let:state let:widget {state} {widget} />
-						<slot name="numberLabel" slot="numberLabel" let:displayedPage let:state let:widget {displayedPage} {state} {widget} />
-						<slot name="pages" slot="pages" let:state let:widget {state} {widget} />
-						<slot name="previous" slot="previous" let:state let:widget {state} {widget} />
-						<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
-					</svelte:component></Slot
-				>{#if state.page === page}<span class="visually-hidden">{state.activeLabel}</span>{/if}
+				>
+					<svelte:fragment slot="slot" let:props><slot name="numberLabel" {...props} /></svelte:fragment>
+					<svelte:component this={component} {...props}>
+						<svelte:fragment slot="ellipsis" let:state let:widget><slot name="ellipsis" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="first" let:state let:widget><slot name="first" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="last" let:state let:widget><slot name="last" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="next" let:state let:widget><slot name="next" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="numberLabel" let:displayedPage let:state let:widget
+							><slot name="numberLabel" {displayedPage} {state} {widget} /></svelte:fragment
+						>
+						<svelte:fragment slot="pages" let:state let:widget><slot name="pages" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="previous" let:state let:widget><slot name="previous" {state} {widget} /></svelte:fragment>
+						<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
+					</svelte:component>
+				</Slot>{#if state.page === page}<span class="visually-hidden">{state.activeLabel}</span>{/if}
 			</a>
 		{/if}
 	</li>

--- a/svelte/lib/src/components/pagination/PaginationDefaultStructure.svelte
+++ b/svelte/lib/src/components/pagination/PaginationDefaultStructure.svelte
@@ -26,16 +26,18 @@
 			>
 				<span aria-hidden="true">
 					<Slot slotContent={state.slotFirst} props={slotContext} let:component let:props>
-						<slot slot="slot" name="first" let:props {...props} />
+						<svelte:fragment slot="slot" let:props><slot name="first" {...props} /></svelte:fragment>
 						<svelte:component this={component} {...props}>
-							<slot name="ellipsis" slot="ellipsis" let:state let:widget {state} {widget} />
-							<slot name="first" slot="first" let:state let:widget {state} {widget} />
-							<slot name="last" slot="last" let:state let:widget {state} {widget} />
-							<slot name="next" slot="next" let:state let:widget {state} {widget} />
-							<slot name="numberLabel" slot="numberLabel" let:displayedPage let:state let:widget {displayedPage} {state} {widget} />
-							<slot name="pages" slot="pages" let:state let:widget {state} {widget} />
-							<slot name="previous" slot="previous" let:state let:widget {state} {widget} />
-							<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+							<svelte:fragment slot="ellipsis" let:state let:widget><slot name="ellipsis" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="first" let:state let:widget><slot name="first" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="last" let:state let:widget><slot name="last" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="next" let:state let:widget><slot name="next" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="numberLabel" let:displayedPage let:state let:widget
+								><slot name="numberLabel" {displayedPage} {state} {widget} /></svelte:fragment
+							>
+							<svelte:fragment slot="pages" let:state let:widget><slot name="pages" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="previous" let:state let:widget><slot name="previous" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 						</svelte:component>
 					</Slot>
 				</span>
@@ -54,16 +56,18 @@
 			>
 				<span aria-hidden="true">
 					<Slot slotContent={state.slotPrevious} props={slotContext} let:component let:props>
-						<slot slot="slot" name="previous" let:props {...props} />
+						<svelte:fragment slot="slot" let:props><slot name="previous" {...props} /></svelte:fragment>
 						<svelte:component this={component} {...props}>
-							<slot name="ellipsis" slot="ellipsis" let:state let:widget {state} {widget} />
-							<slot name="first" slot="first" let:state let:widget {state} {widget} />
-							<slot name="last" slot="last" let:state let:widget {state} {widget} />
-							<slot name="next" slot="next" let:state let:widget {state} {widget} />
-							<slot name="numberLabel" slot="numberLabel" let:displayedPage let:state let:widget {displayedPage} {state} {widget} />
-							<slot name="pages" slot="pages" let:state let:widget {state} {widget} />
-							<slot name="previous" slot="previous" let:state let:widget {state} {widget} />
-							<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+							<svelte:fragment slot="ellipsis" let:state let:widget><slot name="ellipsis" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="first" let:state let:widget><slot name="first" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="last" let:state let:widget><slot name="last" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="next" let:state let:widget><slot name="next" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="numberLabel" let:displayedPage let:state let:widget
+								><slot name="numberLabel" {displayedPage} {state} {widget} /></svelte:fragment
+							>
+							<svelte:fragment slot="pages" let:state let:widget><slot name="pages" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="previous" let:state let:widget><slot name="previous" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 						</svelte:component>
 					</Slot>
 				</span>
@@ -71,16 +75,18 @@
 		</li>
 	{/if}
 	<Slot slotContent={state.slotPages} props={slotContext} let:component let:props>
-		<slot slot="slot" name="pages" let:props {...props} />
+		<svelte:fragment slot="slot" let:props><slot name="pages" {...props} /></svelte:fragment>
 		<svelte:component this={component} {...props}>
-			<slot name="ellipsis" slot="ellipsis" let:state let:widget {state} {widget} />
-			<slot name="first" slot="first" let:state let:widget {state} {widget} />
-			<slot name="last" slot="last" let:state let:widget {state} {widget} />
-			<slot name="next" slot="next" let:state let:widget {state} {widget} />
-			<slot name="numberLabel" slot="numberLabel" let:displayedPage let:state let:widget {displayedPage} {state} {widget} />
-			<slot name="pages" slot="pages" let:state let:widget {state} {widget} />
-			<slot name="previous" slot="previous" let:state let:widget {state} {widget} />
-			<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+			<svelte:fragment slot="ellipsis" let:state let:widget><slot name="ellipsis" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="first" let:state let:widget><slot name="first" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="last" let:state let:widget><slot name="last" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="next" let:state let:widget><slot name="next" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="numberLabel" let:displayedPage let:state let:widget
+				><slot name="numberLabel" {displayedPage} {state} {widget} /></svelte:fragment
+			>
+			<svelte:fragment slot="pages" let:state let:widget><slot name="pages" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="previous" let:state let:widget><slot name="previous" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 		</svelte:component>
 	</Slot>
 	{#if state.directionLinks}
@@ -95,16 +101,18 @@
 			>
 				<span aria-hidden="true">
 					<Slot slotContent={state.slotNext} props={slotContext} let:component let:props>
-						<slot slot="slot" name="next" let:props {...props} />
+						<svelte:fragment slot="slot" let:props><slot name="next" {...props} /></svelte:fragment>
 						<svelte:component this={component} {...props}>
-							<slot name="ellipsis" slot="ellipsis" let:state let:widget {state} {widget} />
-							<slot name="first" slot="first" let:state let:widget {state} {widget} />
-							<slot name="last" slot="last" let:state let:widget {state} {widget} />
-							<slot name="next" slot="next" let:state let:widget {state} {widget} />
-							<slot name="numberLabel" slot="numberLabel" let:displayedPage let:state let:widget {displayedPage} {state} {widget} />
-							<slot name="pages" slot="pages" let:state let:widget {state} {widget} />
-							<slot name="previous" slot="previous" let:state let:widget {state} {widget} />
-							<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+							<svelte:fragment slot="ellipsis" let:state let:widget><slot name="ellipsis" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="first" let:state let:widget><slot name="first" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="last" let:state let:widget><slot name="last" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="next" let:state let:widget><slot name="next" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="numberLabel" let:displayedPage let:state let:widget
+								><slot name="numberLabel" {displayedPage} {state} {widget} /></svelte:fragment
+							>
+							<svelte:fragment slot="pages" let:state let:widget><slot name="pages" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="previous" let:state let:widget><slot name="previous" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 						</svelte:component>
 					</Slot>
 				</span>
@@ -123,16 +131,18 @@
 			>
 				<span aria-hidden="true">
 					<Slot slotContent={state.slotLast} props={slotContext} let:component let:props>
-						<slot slot="slot" name="last" let:props {...props} />
+						<svelte:fragment slot="slot" let:props><slot name="last" {...props} /></svelte:fragment>
 						<svelte:component this={component} {...props}>
-							<slot name="ellipsis" slot="ellipsis" let:state let:widget {state} {widget} />
-							<slot name="first" slot="first" let:state let:widget {state} {widget} />
-							<slot name="last" slot="last" let:state let:widget {state} {widget} />
-							<slot name="next" slot="next" let:state let:widget {state} {widget} />
-							<slot name="numberLabel" slot="numberLabel" let:displayedPage let:state let:widget {displayedPage} {state} {widget} />
-							<slot name="pages" slot="pages" let:state let:widget {state} {widget} />
-							<slot name="previous" slot="previous" let:state let:widget {state} {widget} />
-							<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+							<svelte:fragment slot="ellipsis" let:state let:widget><slot name="ellipsis" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="first" let:state let:widget><slot name="first" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="last" let:state let:widget><slot name="last" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="next" let:state let:widget><slot name="next" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="numberLabel" let:displayedPage let:state let:widget
+								><slot name="numberLabel" {displayedPage} {state} {widget} /></svelte:fragment
+							>
+							<svelte:fragment slot="pages" let:state let:widget><slot name="pages" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="previous" let:state let:widget><slot name="previous" {state} {widget} /></svelte:fragment>
+							<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 						</svelte:component>
 					</Slot>
 				</span>

--- a/svelte/lib/src/components/progressbar/Progressbar.svelte
+++ b/svelte/lib/src/components/progressbar/Progressbar.svelte
@@ -33,10 +33,10 @@
 	aria-valuetext={$ariaValueText$}
 >
 	<Slot slotContent={$slotStructure$} props={slotContext} let:component let:props>
-		<slot slot="slot" name="structure" let:props {...props} />
+		<svelte:fragment slot="slot" let:props><slot name="structure" {...props} /></svelte:fragment>
 		<svelte:component this={component} {...props}>
 			<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-			<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+			<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 		</svelte:component>
 	</Slot>
 </div>

--- a/svelte/lib/src/components/progressbar/ProgressbarDefaultStructure.svelte
+++ b/svelte/lib/src/components/progressbar/ProgressbarDefaultStructure.svelte
@@ -21,10 +21,10 @@
 		style:width={`${state.percentage}%`}
 	>
 		<Slot slotContent={state.slotDefault} props={slotContext} let:component let:props>
-			<slot slot="slot" let:props {...props} />
+			<svelte:fragment slot="slot" let:props><slot {...props} /></svelte:fragment>
 			<svelte:component this={component} {...props}>
 				<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-				<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+				<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 			</svelte:component>
 		</Slot>
 	</div>

--- a/svelte/lib/src/components/rating/Rating.svelte
+++ b/svelte/lib/src/components/rating/Rating.svelte
@@ -73,7 +73,7 @@
 			on:click={() => click(index + 1)}
 		>
 			<Slot slotContent={$slotStar$} props={{fill, index}} let:component let:props>
-				<slot slot="slot" name="star" let:props {...props} />
+				<svelte:fragment slot="slot" let:props><slot name="star" {...props} /></svelte:fragment>
 				<svelte:component this={component} {...props} />
 			</Slot>
 		</span>

--- a/svelte/lib/src/components/select/Select.svelte
+++ b/svelte/lib/src/components/select/Select.svelte
@@ -73,10 +73,12 @@
 			<!-- svelte-ignore a11y-no-static-element-interactions -->
 			<div tabindex="-1" class={`au-select-badge me-1 ${$badgeClassName$}`} on:keydown={(e) => onBadgeKeydown(e, itemContext.item)}>
 				<Slot slotContent={$slotBadgeLabel$} props={{state: $state$, widget, itemContext}} let:component let:props>
-					<slot slot="slot" name="badgeLabel" let:props {...props} />
+					<svelte:fragment slot="slot" let:props><slot name="badgeLabel" {...props} /></svelte:fragment>
 					<svelte:component this={component} {...props}>
-						<slot name="badgeLabel" slot="badgeLabel" let:itemContext let:state let:widget {itemContext} {state} {widget} />
-						<slot name="item" slot="item" let:itemContext let:state let:widget {itemContext} {state} {widget} />
+						<svelte:fragment slot="badgeLabel" let:itemContext let:state let:widget
+							><slot name="badgeLabel" {itemContext} {state} {widget} /></svelte:fragment
+						>
+						<svelte:fragment slot="item" let:itemContext let:state let:widget><slot name="item" {itemContext} {state} {widget} /></svelte:fragment>
 					</svelte:component>
 				</Slot>
 			</div>
@@ -119,10 +121,12 @@
 					style:cursor="pointer"
 				>
 					<Slot slotContent={$slotItem$} props={{state: $state$, widget, itemContext}} let:component let:props>
-						<slot slot="slot" name="item" let:props {...props} />
+						<svelte:fragment slot="slot" let:props><slot name="item" {...props} /></svelte:fragment>
 						<svelte:component this={component} {...props}>
-							<slot name="badgeLabel" slot="badgeLabel" let:itemContext let:state let:widget {itemContext} {state} {widget} />
-							<slot name="item" slot="item" let:itemContext let:state let:widget {itemContext} {state} {widget} />
+							<svelte:fragment slot="badgeLabel" let:itemContext let:state let:widget
+								><slot name="badgeLabel" {itemContext} {state} {widget} /></svelte:fragment
+							>
+							<svelte:fragment slot="item" let:itemContext let:state let:widget><slot name="item" {itemContext} {state} {widget} /></svelte:fragment>
 						</svelte:component>
 					</Slot>
 				</li>

--- a/svelte/lib/src/components/slider/Slider.svelte
+++ b/svelte/lib/src/components/slider/Slider.svelte
@@ -49,11 +49,11 @@
 	aria-disabled={$disabled$ ? true : null}
 >
 	<Slot slotContent={$slotStructure$} props={slotContext} let:component let:props>
-		<slot slot="slot" name="structure" let:props {...props} />
+		<svelte:fragment slot="slot" let:props><slot name="structure" {...props} /></svelte:fragment>
 		<svelte:component this={component} {...props}>
-			<slot name="handle" slot="handle" let:item let:state let:widget {item} {state} {widget} />
-			<slot name="label" slot="label" let:state let:value let:widget {state} {value} {widget} />
-			<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+			<svelte:fragment slot="handle" let:item let:state let:widget><slot name="handle" {item} {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="label" let:state let:value let:widget><slot name="label" {state} {value} {widget} /></svelte:fragment>
+			<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 		</svelte:component>
 	</Slot>
 </div>

--- a/svelte/lib/src/components/slider/SliderDefaultStructure.svelte
+++ b/svelte/lib/src/components/slider/SliderDefaultStructure.svelte
@@ -33,11 +33,11 @@
 		use:widget.directives.minLabelDirective
 	>
 		<Slot slotContent={state.slotLabel} props={{value: state.min, ...slotContext}} let:component let:props>
-			<slot slot="slot" name="label" let:props {...props} />
+			<svelte:fragment slot="slot" let:props><slot name="label" {...props} /></svelte:fragment>
 			<svelte:component this={component} {...props}>
-				<slot name="handle" slot="handle" let:item let:state let:widget {item} {state} {widget} />
-				<slot name="label" slot="label" let:state let:value let:widget {state} {value} {widget} />
-				<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+				<svelte:fragment slot="handle" let:item let:state let:widget><slot name="handle" {item} {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="label" let:state let:value let:widget><slot name="label" {state} {value} {widget} /></svelte:fragment>
+				<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 			</svelte:component>
 		</Slot>
 	</div>
@@ -48,11 +48,11 @@
 		use:widget.directives.maxLabelDirective
 	>
 		<Slot slotContent={state.slotLabel} props={{value: state.max, ...slotContext}} let:component let:props>
-			<slot slot="slot" name="label" let:props {...props} />
+			<svelte:fragment slot="slot" let:props><slot name="label" {...props} /></svelte:fragment>
 			<svelte:component this={component} {...props}>
-				<slot name="handle" slot="handle" let:item let:state let:widget {item} {state} {widget} />
-				<slot name="label" slot="label" let:state let:value let:widget {state} {value} {widget} />
-				<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+				<svelte:fragment slot="handle" let:item let:state let:widget><slot name="handle" {item} {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="label" let:state let:value let:widget><slot name="label" {state} {value} {widget} /></svelte:fragment>
+				<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 			</svelte:component>
 		</Slot>
 	</div>
@@ -65,36 +65,36 @@
 	>
 		{#if state.rtl}
 			<Slot slotContent={state.slotLabel} props={{value: state.sortedValues[1], ...slotContext}} let:component let:props>
-				<slot slot="slot" name="label" let:props {...props} />
+				<svelte:fragment slot="slot" let:props><slot name="label" {...props} /></svelte:fragment>
 				<svelte:component this={component} {...props}>
-					<slot name="handle" slot="handle" let:item let:state let:widget {item} {state} {widget} />
-					<slot name="label" slot="label" let:state let:value let:widget {state} {value} {widget} />
-					<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+					<svelte:fragment slot="handle" let:item let:state let:widget><slot name="handle" {item} {state} {widget} /></svelte:fragment>
+					<svelte:fragment slot="label" let:state let:value let:widget><slot name="label" {state} {value} {widget} /></svelte:fragment>
+					<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 				</svelte:component>
 			</Slot> -
 			<Slot slotContent={state.slotLabel} props={{value: state.sortedValues[0], ...slotContext}} let:component let:props>
-				<slot slot="slot" name="label" let:props {...props} />
+				<svelte:fragment slot="slot" let:props><slot name="label" {...props} /></svelte:fragment>
 				<svelte:component this={component} {...props}>
-					<slot name="handle" slot="handle" let:item let:state let:widget {item} {state} {widget} />
-					<slot name="label" slot="label" let:state let:value let:widget {state} {value} {widget} />
-					<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+					<svelte:fragment slot="handle" let:item let:state let:widget><slot name="handle" {item} {state} {widget} /></svelte:fragment>
+					<svelte:fragment slot="label" let:state let:value let:widget><slot name="label" {state} {value} {widget} /></svelte:fragment>
+					<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 				</svelte:component>
 			</Slot>
 		{:else}
 			<Slot slotContent={state.slotLabel} props={{value: state.sortedValues[0], ...slotContext}} let:component let:props>
-				<slot slot="slot" name="label" let:props {...props} />
+				<svelte:fragment slot="slot" let:props><slot name="label" {...props} /></svelte:fragment>
 				<svelte:component this={component} {...props}>
-					<slot name="handle" slot="handle" let:item let:state let:widget {item} {state} {widget} />
-					<slot name="label" slot="label" let:state let:value let:widget {state} {value} {widget} />
-					<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+					<svelte:fragment slot="handle" let:item let:state let:widget><slot name="handle" {item} {state} {widget} /></svelte:fragment>
+					<svelte:fragment slot="label" let:state let:value let:widget><slot name="label" {state} {value} {widget} /></svelte:fragment>
+					<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 				</svelte:component>
 			</Slot> -
 			<Slot slotContent={state.slotLabel} props={{value: state.sortedValues[1], ...slotContext}} let:component let:props>
-				<slot slot="slot" name="label" let:props {...props} />
+				<svelte:fragment slot="slot" let:props><slot name="label" {...props} /></svelte:fragment>
 				<svelte:component this={component} {...props}>
-					<slot name="handle" slot="handle" let:item let:state let:widget {item} {state} {widget} />
-					<slot name="label" slot="label" let:state let:value let:widget {state} {value} {widget} />
-					<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+					<svelte:fragment slot="handle" let:item let:state let:widget><slot name="handle" {item} {state} {widget} /></svelte:fragment>
+					<svelte:fragment slot="label" let:state let:value let:widget><slot name="label" {state} {value} {widget} /></svelte:fragment>
+					<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 				</svelte:component>
 			</Slot>
 		{/if}
@@ -102,11 +102,11 @@
 {/if}
 {#each state.sortedHandles as item, i (item.id)}
 	<Slot slotContent={state.slotHandle} props={{item, ...slotContext}} let:component let:props>
-		<slot slot="slot" name="handle" let:props {...props} />
+		<svelte:fragment slot="slot" let:props><slot name="handle" {...props} /></svelte:fragment>
 		<svelte:component this={component} {...props}>
-			<slot name="handle" slot="handle" let:item let:state let:widget {item} {state} {widget} />
-			<slot name="label" slot="label" let:state let:value let:widget {state} {value} {widget} />
-			<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+			<svelte:fragment slot="handle" let:item let:state let:widget><slot name="handle" {item} {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="label" let:state let:value let:widget><slot name="label" {state} {value} {widget} /></svelte:fragment>
+			<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 		</svelte:component>
 	</Slot>
 	{#if state.showValueLabels && !state.combinedLabelDisplay}
@@ -116,11 +116,11 @@
 			style:top={`${state.handleDisplayOptions[i].top}%`}
 		>
 			<Slot slotContent={state.slotLabel} props={{value: state.values[i], ...slotContext}} let:component let:props>
-				<slot slot="slot" name="label" let:props {...props} />
+				<svelte:fragment slot="slot" let:props><slot name="label" {...props} /></svelte:fragment>
 				<svelte:component this={component} {...props}>
-					<slot name="handle" slot="handle" let:item let:state let:widget {item} {state} {widget} />
-					<slot name="label" slot="label" let:state let:value let:widget {state} {value} {widget} />
-					<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+					<svelte:fragment slot="handle" let:item let:state let:widget><slot name="handle" {item} {state} {widget} /></svelte:fragment>
+					<svelte:fragment slot="label" let:state let:value let:widget><slot name="label" {state} {value} {widget} /></svelte:fragment>
+					<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 				</svelte:component>
 			</Slot>
 		</div>

--- a/svelte/lib/src/components/toast/Toast.svelte
+++ b/svelte/lib/src/components/toast/Toast.svelte
@@ -50,11 +50,11 @@
 		use:autoHideDirective
 	>
 		<Slot slotContent={$slotStructure$} props={slotContext} let:component let:props>
-			<slot slot="slot" name="structure" let:props {...props} />
+			<svelte:fragment slot="slot" let:props><slot name="structure" {...props} /></svelte:fragment>
 			<svelte:component this={component} {...props}>
 				<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-				<slot name="header" slot="header" let:state let:widget {state} {widget} />
-				<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+				<svelte:fragment slot="header" let:state let:widget><slot name="header" {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 			</svelte:component>
 		</Slot>
 	</div>

--- a/svelte/lib/src/components/toast/ToastDefaultStructure.svelte
+++ b/svelte/lib/src/components/toast/ToastDefaultStructure.svelte
@@ -16,11 +16,11 @@
 {#if state.slotHeader}
 	<div class="toast-header">
 		<Slot slotContent={state.slotHeader} props={slotContext} let:component let:props>
-			<slot slot="slot" name="header" let:props {...props} />
+			<svelte:fragment slot="slot" let:props><slot name="header" {...props} /></svelte:fragment>
 			<svelte:component this={component} {...props}>
 				<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-				<slot name="header" slot="header" let:state let:widget {state} {widget} />
-				<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+				<svelte:fragment slot="header" let:state let:widget><slot name="header" {state} {widget} /></svelte:fragment>
+				<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 			</svelte:component>
 		</Slot>
 		{#if state.dismissible}
@@ -31,11 +31,11 @@
 
 <div class="toast-body">
 	<Slot slotContent={state.slotDefault} props={slotContext} let:component let:props>
-		<slot slot="slot" let:props {...props} />
+		<svelte:fragment slot="slot" let:props><slot {...props} /></svelte:fragment>
 		<svelte:component this={component} {...props}>
 			<svelte:fragment let:state let:widget><slot {state} {widget} /></svelte:fragment>
-			<slot name="header" slot="header" let:state let:widget {state} {widget} />
-			<slot name="structure" slot="structure" let:state let:widget {state} {widget} />
+			<svelte:fragment slot="header" let:state let:widget><slot name="header" {state} {widget} /></svelte:fragment>
+			<svelte:fragment slot="structure" let:state let:widget><slot name="structure" {state} {widget} /></svelte:fragment>
 		</svelte:component>
 	</Slot>
 </div>


### PR DESCRIPTION
This PR reverts #522 and implements the workaround mentioned in https://github.com/sveltejs/svelte/issues/9137, which is replacing:
```svelte
<MyComponent>
<slot name="otherComponentSlot" slot="myComponentSlot" let:props {...props}/>
</MyComponent>
```
by:
```svelte
<MyComponent>
<svelte:fragment slot="myComponentSlot" let:props><slot name="otherComponentSlot" {...props}/></svelte:fragment>
</MyComponent>
```