### PR TITLE
refactor(react): avoid calling useDirective when element is not in the DOM

### DIFF
--- a/react/bootstrap/src/components/accordion/accordion.tsx
+++ b/react/bootstrap/src/components/accordion/accordion.tsx
@@ -31,27 +31,26 @@ const Header = (props: PropsWithChildren<{headerTag: string; directive: Directiv
 	);
 };
 
+const ItemContent = (slotContext: AccordionItemContext) => (
+	<div className="accordion-collapse" {...useDirective(slotContext.widget.directives.bodyContainerDirective)}>
+		<div className="accordion-body" {...useDirective(slotContext.widget.directives.bodyDirective)}>
+			<Slot slotContent={slotContext.state.slotItemBody} props={slotContext}></Slot>
+		</div>
+	</div>
+);
+
 const AccordionDIContext: React.Context<Partial<AccordionApi>> = createContext({});
-const DefaultSlotStructure = (slotContext: AccordionItemContext) => {
-	const bodyContainerSetRef = useDirective(slotContext.widget.directives.bodyContainerDirective);
-	const bodySetRef = useDirective(slotContext.widget.directives.bodyDirective);
-	return (
-		<>
-			<Header directive={slotContext.widget.directives.headerDirective} headerTag={slotContext.state.itemHeadingTag}>
-				<button className="accordion-button" {...useDirective(slotContext.widget.directives.buttonDirective)}>
-					<Slot slotContent={slotContext.state.slotItemHeader} props={slotContext}></Slot>
-				</button>
-			</Header>
-			{slotContext.state.shouldBeInDOM ? (
-				<div className="accordion-collapse" {...bodyContainerSetRef}>
-					<div className="accordion-body" {...bodySetRef}>
-						<Slot slotContent={slotContext.state.slotItemBody} props={slotContext}></Slot>
-					</div>
-				</div>
-			) : null}
-		</>
-	);
-};
+const DefaultSlotStructure = (slotContext: AccordionItemContext) => (
+	<>
+		<Header directive={slotContext.widget.directives.headerDirective} headerTag={slotContext.state.itemHeadingTag}>
+			<button className="accordion-button" {...useDirective(slotContext.widget.directives.buttonDirective)}>
+				<Slot slotContent={slotContext.state.slotItemHeader} props={slotContext}></Slot>
+			</button>
+		</Header>
+		{slotContext.state.shouldBeInDOM && <ItemContent {...slotContext} />}
+	</>
+);
+
 const defaultConfig: Partial<AccordionItemProps> = {
 	slotItemStructure: DefaultSlotStructure,
 };

--- a/react/bootstrap/src/components/alert/alert.tsx
+++ b/react/bootstrap/src/components/alert/alert.tsx
@@ -30,29 +30,26 @@ const defaultConfig: Partial<AlertProps> = {
 	slotStructure: DefaultSlotStructure,
 };
 
+const AlertElement = (slotContext: AlertContext) => (
+	<div
+		className={`au-alert alert alert-${slotContext.state.type} ${slotContext.state.className} ${slotContext.state.dismissible ? 'alert-dismissible' : ''}`}
+		role="alert"
+		{...useDirective(slotContext.widget.directives.transitionDirective)}
+	>
+		<Slot slotContent={slotContext.state.slotStructure} props={slotContext}></Slot>
+	</div>
+);
+
 export const Alert: ForwardRefExoticComponent<PropsWithChildren<Partial<AlertProps>> & RefAttributes<AlertApi>> = forwardRef(function Alert(
 	props: PropsWithChildren<Partial<AlertProps>>,
 	ref: ForwardedRef<AlertApi>,
 ) {
 	const [state, widget] = useWidgetWithConfig(createAlert, props, 'alert', {...defaultConfig, slotDefault: props.children});
-	const refTransition = useDirective(widget.directives.transitionDirective);
 	useImperativeHandle(ref, () => widget.api, []);
 	const slotContext = {
 		state,
 		widget,
 	};
 
-	return (
-		<>
-			{state.hidden ? null : (
-				<div
-					className={`au-alert alert alert-${state.type} ${state.className} ${state.dismissible ? 'alert-dismissible' : ''}`}
-					role="alert"
-					{...refTransition}
-				>
-					<Slot slotContent={state.slotStructure} props={slotContext}></Slot>
-				</div>
-			)}
-		</>
-	);
+	return <>{!state.hidden && <AlertElement {...slotContext} />}</>;
 });

--- a/react/bootstrap/src/components/modal/modal.tsx
+++ b/react/bootstrap/src/components/modal/modal.tsx
@@ -53,27 +53,31 @@ const defaultConfig: Partial<ModalProps<any>> = {
 	slotStructure: DefaultSlotStructure,
 };
 
+const BackdropElement = <Data,>({widget}: ModalContext<Data>) => (
+	<div className="modal-backdrop" {...useDirective(widget.directives.backdropDirective)} />
+);
+
+const ModalElement = <Data,>(slotContext: ModalContext<Data>) => (
+	<div className="modal d-block" {...useDirective(slotContext.widget.directives.modalDirective)}>
+		<div className="modal-dialog">
+			<div className="modal-content">
+				<Slot slotContent={slotContext.state.slotStructure} props={slotContext} />
+			</div>
+		</div>
+	</div>
+);
+
 export const Modal = forwardRef(function Modal<Data>(props: PropsWithChildren<Partial<ModalProps<Data>>>, ref: Ref<ModalApi<Data>>) {
 	const [state, widget] = useWidgetWithConfig(createModal<Data>, props, 'modal', {...defaultConfig, slotDefault: props.children});
 	useImperativeHandle(ref, () => widget.api, []);
-	const refSetBackdrop = useDirective(widget.directives.backdropDirective);
-	const refSetModal = useDirective(widget.directives.modalDirective);
 	const slotContext: ModalContext<Data> = {
 		state,
 		widget: toSlotContextWidget(widget),
 	};
 	return (
 		<Portal container={state.container}>
-			{!state.backdropHidden && <div className={`modal-backdrop`} {...refSetBackdrop} />}
-			{!state.hidden && (
-				<div className={`modal d-block`} {...refSetModal}>
-					<div className="modal-dialog">
-						<div className="modal-content">
-							<Slot slotContent={state.slotStructure} props={slotContext} />
-						</div>
-					</div>
-				</div>
-			)}
+			{!state.backdropHidden && <BackdropElement {...slotContext} />}
+			{!state.hidden && <ModalElement {...slotContext} />}
 		</Portal>
 	);
 }) as <Data>(props: PropsWithChildren<Partial<ModalProps<Data>>> & RefAttributes<ModalApi<Data>>) => JSX.Element;

--- a/react/bootstrap/src/components/select/select.tsx
+++ b/react/bootstrap/src/components/select/select.tsx
@@ -51,11 +51,19 @@ function Badges<Item>({slotContext}: {slotContext: SelectContext<Item>}) {
 	return badges.length ? <>{badges}</> : null;
 }
 
-function Rows<Item>({slotContext}: {slotContext: SelectContext<Item>}) {
+function Rows<Item>({slotContext, menuId}: {slotContext: SelectContext<Item>; menuId: string}) {
 	const {widget, state} = slotContext;
-	const highlighted = state.highlighted;
+	const {placement, menuClassName, highlighted} = state;
+	const {hasFocusDirective, floatingDirective} = widget.directives;
 	return (
-		<>
+		<ul
+			role="listbox"
+			id={menuId}
+			className={`dropdown-menu show ${menuClassName}`}
+			data-popper-placement={placement}
+			onMouseDown={preventDefault}
+			{...useDirectives([hasFocusDirective, floatingDirective])}
+		>
 			{state.visibleItems.map((itemContext) => {
 				const {id} = itemContext;
 				const classname = ['au-select-item dropdown-item position-relative'];
@@ -78,7 +86,7 @@ function Rows<Item>({slotContext}: {slotContext: SelectContext<Item>}) {
 					</li>
 				);
 			})}
-		</>
+		</ul>
 	);
 }
 
@@ -90,13 +98,12 @@ const defaultConfig: Partial<SelectProps<any>> = {
 export function Select<Item>(props: Partial<SelectProps<Item>>) {
 	const [state, widget] = useWidgetWithConfig<SelectWidget<Item>>(createSelect, props, 'select', defaultConfig);
 	const slotContext: SelectContext<Item> = {state, widget: toSlotContextWidget(widget)};
-	const {id, ariaLabel, visibleItems, filterText, open, className, menuClassName, placement} = state;
+	const {id, ariaLabel, visibleItems, filterText, open, className} = state;
 	const menuId = `${id}-menu`;
 
 	const {
-		directives: {floatingDirective, hasFocusDirective, referenceDirective, inputContainerDirective},
+		directives: {hasFocusDirective, referenceDirective, inputContainerDirective},
 	} = widget;
-	const refSetMenu = useDirectives([hasFocusDirective, floatingDirective]);
 	return (
 		<div className={`au-select dropdown border border-1 p-1 mb-3 d-block ${className}`} {...useDirective(referenceDirective)}>
 			<div
@@ -122,18 +129,7 @@ export function Select<Item>(props: Partial<SelectProps<Item>>) {
 					onKeyDown={(e) => widget.actions.onInputKeydown(e.nativeEvent)}
 				/>
 			</div>
-			{open && visibleItems.length > 0 && (
-				<ul
-					{...refSetMenu}
-					role="listbox"
-					id={menuId}
-					className={`dropdown-menu show ${menuClassName}`}
-					data-popper-placement={placement}
-					onMouseDown={preventDefault}
-				>
-					<Rows slotContext={slotContext}></Rows>
-				</ul>
-			)}
+			{open && visibleItems.length > 0 && <Rows slotContext={slotContext} menuId={menuId} />}
 		</div>
 	);
 }

--- a/react/bootstrap/src/components/slider/slider.tsx
+++ b/react/bootstrap/src/components/slider/slider.tsx
@@ -36,64 +36,57 @@ const HandleLabelDisplay = ({
 }) => {
 	return <div {...useDirective(directive, {index})}>{children}</div>;
 };
-export const DefaultSlotStructure = (slotContext: SliderContext) => {
-	const minSetRef = useDirective(slotContext.widget.directives.minLabelDirective);
-	const maxSetRef = useDirective(slotContext.widget.directives.maxLabelDirective);
-	const combinedHandleLabelDisplaySetRef = useDirective(slotContext.widget.directives.combinedHandleLabelDisplayDirective);
 
-	return (
-		<>
-			{slotContext.state.progressDisplayOptions.map((option, index) => (
-				<ProgressDisplay key={index} directive={slotContext.widget.directives.progressDisplayDirective} option={option} />
-			))}
-			<div {...useDirective(slotContext.widget.directives.clickableAreaDirective)} />
-			{slotContext.state.showMinMaxLabels ? (
-				<>
-					<div {...minSetRef}>
-						<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.min, ...slotContext}} />
-					</div>
-					<div {...maxSetRef}>
-						<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.max, ...slotContext}} />
-					</div>
-				</>
-			) : (
-				<></>
-			)}
-			{slotContext.state.showValueLabels && slotContext.state.combinedLabelDisplay ? (
-				<div {...combinedHandleLabelDisplaySetRef}>
-					{slotContext.state.rtl ? (
-						<>
-							<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.sortedValues[1], ...slotContext}} />
-							{' - '}
-							<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.sortedValues[0], ...slotContext}} />
-						</>
-					) : (
-						<>
-							<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.sortedValues[0], ...slotContext}} />
-							{' - '}
-							<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.sortedValues[1], ...slotContext}} />
-						</>
-					)}
-				</div>
-			) : (
-				<></>
-			)}
+const MinMaxLabels = (slotContext: SliderContext) => (
+	<>
+		<div {...useDirective(slotContext.widget.directives.minLabelDirective)}>
+			<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.min, ...slotContext}} />
+		</div>
+		<div {...useDirective(slotContext.widget.directives.maxLabelDirective)}>
+			<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.max, ...slotContext}} />
+		</div>
+	</>
+);
 
-			{slotContext.state.sortedHandles.map((item, i) => (
-				<React.Fragment key={item.id}>
-					<Slot slotContent={slotContext.state.slotHandle} props={{item, ...slotContext}} />
-					{slotContext.state.showValueLabels && !slotContext.state.combinedLabelDisplay ? (
-						<HandleLabelDisplay directive={slotContext.widget.directives.handleLabelDisplayDirective} index={i}>
-							<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.values[i], ...slotContext}} />
-						</HandleLabelDisplay>
-					) : (
-						<></>
-					)}
-				</React.Fragment>
-			))}
-		</>
-	);
-};
+const CombinedLabel = (slotContext: SliderContext) => (
+	<div {...useDirective(slotContext.widget.directives.combinedHandleLabelDisplayDirective)}>
+		{slotContext.state.rtl ? (
+			<>
+				<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.sortedValues[1], ...slotContext}} />
+				{' - '}
+				<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.sortedValues[0], ...slotContext}} />
+			</>
+		) : (
+			<>
+				<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.sortedValues[0], ...slotContext}} />
+				{' - '}
+				<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.sortedValues[1], ...slotContext}} />
+			</>
+		)}
+	</div>
+);
+
+export const DefaultSlotStructure = (slotContext: SliderContext) => (
+	<>
+		{slotContext.state.progressDisplayOptions.map((option, index) => (
+			<ProgressDisplay key={index} directive={slotContext.widget.directives.progressDisplayDirective} option={option} />
+		))}
+		<div {...useDirective(slotContext.widget.directives.clickableAreaDirective)} />
+		{slotContext.state.showMinMaxLabels && <MinMaxLabels {...slotContext} />}
+		{slotContext.state.showValueLabels && slotContext.state.combinedLabelDisplay && <CombinedLabel {...slotContext} />}
+
+		{slotContext.state.sortedHandles.map((item, i) => (
+			<React.Fragment key={item.id}>
+				<Slot slotContent={slotContext.state.slotHandle} props={{item, ...slotContext}} />
+				{slotContext.state.showValueLabels && !slotContext.state.combinedLabelDisplay && (
+					<HandleLabelDisplay directive={slotContext.widget.directives.handleLabelDisplayDirective} index={i}>
+						<Slot slotContent={slotContext.state.slotLabel} props={{value: slotContext.state.values[i], ...slotContext}} />
+					</HandleLabelDisplay>
+				)}
+			</React.Fragment>
+		))}
+	</>
+);
 
 const defaultConfig: Partial<SliderProps> = {
 	slotStructure: DefaultSlotStructure,

--- a/react/bootstrap/src/components/toast/toast.tsx
+++ b/react/bootstrap/src/components/toast/toast.tsx
@@ -15,50 +15,57 @@ export type ToastState = WidgetState<ToastWidget>;
 export type ToastContext = AdaptSlotContentProps<import('@agnos-ui/core-bootstrap/components/toast').ToastContext>;
 export const createToast: WidgetFactory<ToastWidget> = coreCreateToast as any;
 
-const DefaultSlotStructure = (slotContext: ToastContext) => {
-	const refCloseButton = useDirective(slotContext.widget.directives.closeButtonDirective);
-	return (
-		<>
-			{slotContext.state.slotHeader && (
-				<div className="toast-header">
-					<Slot slotContent={slotContext.state.slotHeader} props={slotContext} />
-					{slotContext.state.dismissible && <button className="btn-close me-0 ms-auto" {...refCloseButton} />}
-				</div>
-			)}
+const ToastHeader = (slotContext: ToastContext) => (
+	<div className="toast-header">
+		<Slot slotContent={slotContext.state.slotHeader} props={slotContext} />
+		{slotContext.state.dismissible && (
+			<button className="btn-close me-0 ms-auto" {...useDirective(slotContext.widget.directives.closeButtonDirective)} />
+		)}
+	</div>
+);
 
-			<div className="toast-body">
-				<Slot slotContent={slotContext.state.slotDefault} props={slotContext} />
-			</div>
-			{slotContext.state.dismissible && !slotContext.state.slotHeader && (
-				<button className="btn-close btn-close-white me-2 m-auto" {...refCloseButton} />
-			)}
-		</>
-	);
-};
+const ToastCloseButtonNoHeader = (slotContext: ToastContext) => (
+	<button className="btn-close btn-close-white me-2 m-auto" {...useDirective(slotContext.widget.directives.closeButtonDirective)} />
+);
+
+const DefaultSlotStructure = (slotContext: ToastContext) => (
+	<>
+		{slotContext.state.slotHeader && <ToastHeader {...slotContext} />}
+
+		<div className="toast-body">
+			<Slot slotContent={slotContext.state.slotDefault} props={slotContext} />
+		</div>
+		{slotContext.state.dismissible && !slotContext.state.slotHeader && <ToastCloseButtonNoHeader {...slotContext} />}
+	</>
+);
 
 const defaultConfig: Partial<ToastProps> = {
 	slotStructure: DefaultSlotStructure,
 };
+
+const ToastElement = (slotContext: ToastContext) => (
+	<div
+		className={`toast ${slotContext.state.dismissible ? 'toast-dismissible' : ''} ${!slotContext.state.slotHeader ? 'd-flex' : ''}`}
+		{...useDirectives([
+			slotContext.widget.directives.transitionDirective,
+			slotContext.widget.directives.autoHideDirective,
+			slotContext.widget.directives.bodyDirective,
+		])}
+	>
+		<Slot slotContent={slotContext.state.slotStructure} props={slotContext} />
+	</div>
+);
 
 export const Toast: ForwardRefExoticComponent<PropsWithChildren<Partial<ToastProps>> & RefAttributes<ToastApi>> = forwardRef(function Toast(
 	props: PropsWithChildren<Partial<ToastProps>>,
 	ref,
 ) {
 	const [state, widget] = useWidgetWithConfig(createToast, props, 'toast', {...defaultConfig, slotDefault: props.children});
-	const refToast = useDirectives([widget.directives.transitionDirective, widget.directives.autoHideDirective, widget.directives.bodyDirective]);
 	useImperativeHandle(ref, () => widget.api, []);
 	const slotContext = {
 		state,
 		widget,
 	};
 
-	return (
-		<>
-			{!state.hidden && (
-				<div className={`toast ${state.dismissible ? 'toast-dismissible' : ''} ${!state.slotHeader ? 'd-flex' : ''}`} {...refToast}>
-					<Slot slotContent={state.slotStructure} props={slotContext} />
-				</div>
-			)}
-		</>
-	);
+	return <>{!state.hidden && <ToastElement {...slotContext} />}</>;
 });


### PR DESCRIPTION
This PR refactors some react components to avoid calling `useDirective` when the element is not in the DOM.
This is important for SSR because soon (in a future PR), `useDirective` will call `ssrAttributes` and this will call the directive on the server, and this must be skipped if the element will not be in the DOM (as it is useless and because it can cause some errors).
As it is not allowed to call a hook a variable number of times in a component, some react components had to be split in smaller components.
