### PR TITLE
feat: multiDirective and corresponding refactoring in react and Angular

### DIFF
--- a/angular/bootstrap/src/agnos-ui-angular.module.ts
+++ b/angular/bootstrap/src/agnos-ui-angular.module.ts
@@ -1,4 +1,4 @@
-import {SlotDirective, UseDirective} from '@agnos-ui/angular-headless';
+import {SlotDirective, UseDirective, UseMultiDirective} from '@agnos-ui/angular-headless';
 import {NgModule} from '@angular/core';
 import {
 	ModalBodyDirective,
@@ -39,6 +39,7 @@ const components = [
 	SelectBadgeLabelDirective,
 	SelectItemDirective,
 	UseDirective,
+	UseMultiDirective,
 	RatingComponent,
 	RatingStarDirective,
 	PaginationComponent,

--- a/angular/bootstrap/src/components/modal/modal.component.ts
+++ b/angular/bootstrap/src/components/modal/modal.component.ts
@@ -1,13 +1,12 @@
 import type {SlotContent, TransitionFn} from '@agnos-ui/angular-headless';
 import {
 	BaseWidgetDirective,
-	CachedProperty,
 	ComponentTemplate,
 	SlotDefaultDirective,
 	SlotDirective,
 	UseDirective,
+	UseMultiDirective,
 	auBooleanAttribute,
-	mergeDirectives,
 } from '@agnos-ui/angular-headless';
 import type {ModalContext, ModalProps, ModalWidget, ModalBeforeCloseEvent} from './modal';
 import {createModal} from './modal';
@@ -142,14 +141,14 @@ const defaultConfig: Partial<ModalProps<any>> = {
 	selector: '[auModal]',
 	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	imports: [UseDirective, SlotDirective, SlotDefaultDirective],
+	imports: [UseMultiDirective, SlotDirective, SlotDefaultDirective],
 	template: `
 		<ng-template [auSlotDefault]="defaultSlots"><ng-content></ng-content></ng-template>
 		@if (!state().backdropHidden) {
-			<div class="modal-backdrop" [auUse]="backdropDirective"></div>
+			<div class="modal-backdrop" [auUseMulti]="[widget.directives.backdropPortalDirective, widget.directives.backdropDirective]"></div>
 		}
 		@if (!state().hidden) {
-			<div class="modal d-block" [auUse]="modalDirective">
+			<div class="modal d-block" [auUseMulti]="[widget.directives.modalPortalDirective, widget.directives.modalDirective]">
 				<div class="modal-dialog">
 					<div class="modal-content">
 						<ng-template [auSlot]="state().slotStructure" [auSlotProps]="{state: state(), widget}"></ng-template>
@@ -275,16 +274,6 @@ export class ModalComponent<Data> extends BaseWidgetDirective<ModalWidget<Data>>
 			onVisibleChange: (event) => this.visibleChange.emit(event),
 		},
 	});
-
-	@CachedProperty
-	get modalDirective() {
-		return mergeDirectives(this._widget.directives.modalPortalDirective, this._widget.directives.modalDirective);
-	}
-
-	@CachedProperty
-	get backdropDirective() {
-		return mergeDirectives(this._widget.directives.backdropPortalDirective, this._widget.directives.backdropDirective);
-	}
 
 	ngAfterContentChecked(): void {
 		this._widget.patchSlots({

--- a/angular/bootstrap/src/components/rating/rating.component.ts
+++ b/angular/bootstrap/src/components/rating/rating.component.ts
@@ -48,7 +48,7 @@ export class RatingStarDirective {
 	template: `
 		@for (item of state().stars; track trackByIndex(index); let index = $index) {
 			<span class="visually-hidden">({{ index < state().visibleRating ? '*' : ' ' }})</span>
-			<span [auUse]="_widget.directives.starDirective" [auUseParams]="{index}">
+			<span [auUse]="[_widget.directives.starDirective, {index}]">
 				<ng-template [auSlot]="state().slotStar" [auSlotProps]="state().stars[index]"></ng-template>
 			</span>
 		}

--- a/angular/bootstrap/src/components/select/select.component.ts
+++ b/angular/bootstrap/src/components/select/select.component.ts
@@ -1,13 +1,5 @@
 import type {AdaptSlotContentProps, SlotContent} from '@agnos-ui/angular-headless';
-import {
-	BaseWidgetDirective,
-	CachedProperty,
-	SlotDirective,
-	UseDirective,
-	auBooleanAttribute,
-	mergeDirectives,
-	useDirectiveForHost,
-} from '@agnos-ui/angular-headless';
+import {BaseWidgetDirective, SlotDirective, UseMultiDirective, auBooleanAttribute, useDirectiveForHost} from '@agnos-ui/angular-headless';
 import type {AfterContentChecked} from '@angular/core';
 import {ChangeDetectionStrategy, Component, ContentChild, Directive, EventEmitter, Input, Output, TemplateRef, inject} from '@angular/core';
 import type {Placement} from '@floating-ui/dom';
@@ -33,7 +25,7 @@ export class SelectItemDirective<Item> {
 
 @Component({
 	standalone: true,
-	imports: [UseDirective, SlotDirective],
+	imports: [UseMultiDirective, SlotDirective],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	selector: '[auSelect]',
 	host: {
@@ -42,7 +34,7 @@ export class SelectItemDirective<Item> {
 	template: `
 		@if (state(); as state) {
 			<div
-				[auUse]="controlContainerDirective"
+				[auUseMulti]="[widget.directives.hasFocusDirective, widget.directives.inputContainerDirective]"
 				role="combobox"
 				class="d-flex align-items-center flex-wrap"
 				[attr.aria-controls]="state.id + '-menu'"
@@ -79,7 +71,7 @@ export class SelectItemDirective<Item> {
 				<ul
 					role="listbox"
 					[id]="state.id + '-menu'"
-					[auUse]="menuDirective"
+					[auUseMulti]="[widget.directives.hasFocusDirective, widget.directives.floatingDirective]"
 					[class]="'dropdown-menu show ' + (menuClassName || '')"
 					[attr.data-popper-placement]="state.placement"
 					(mousedown)="$event.preventDefault()"
@@ -213,16 +205,6 @@ export class SelectComponent<Item> extends BaseWidgetDirective<SelectWidget<Item
 			useDirectiveForHost(this._widget.directives.referenceDirective);
 		},
 	});
-
-	@CachedProperty
-	get menuDirective() {
-		return mergeDirectives(this._widget.directives.hasFocusDirective, this._widget.directives.floatingDirective);
-	}
-
-	@CachedProperty
-	get controlContainerDirective() {
-		return mergeDirectives(this._widget.directives.hasFocusDirective, this._widget.directives.inputContainerDirective);
-	}
 
 	itemCtxTrackBy(_: number, itemContext: ItemContext<Item>) {
 		return itemContext.id;

--- a/angular/bootstrap/src/components/slider/slider.component.ts
+++ b/angular/bootstrap/src/components/slider/slider.component.ts
@@ -54,7 +54,7 @@ export class SliderHandleDirective {
 	imports: [UseDirective, SliderHandleDirective],
 	template: `
 		<ng-template auSliderHandle #handle let-state="state" let-widget="widget" let-item="item">
-			<button [auUse]="widget.directives.handleDirective" [auUseParams]="{item}">&nbsp;</button>
+			<button [auUse]="[widget.directives.handleDirective, {item}]">&nbsp;</button>
 		</ng-template>
 	`,
 })
@@ -88,7 +88,7 @@ export class SliderStructureDirective {
 	template: `
 		<ng-template auSliderStructure #structure let-state="state" let-widget="widget">
 			@for (option of state.progressDisplayOptions; track option) {
-				<div [auUse]="widget.directives.progressDisplayDirective" [auUseParams]="{option}"></div>
+				<div [auUse]="[widget.directives.progressDisplayDirective, {option}]"></div>
 			}
 			<div [auUse]="widget.directives.clickableAreaDirective"></div>
 			@if (state.showMinMaxLabels) {
@@ -113,7 +113,7 @@ export class SliderStructureDirective {
 			@for (item of state.sortedHandles; track item.id; let i = $index) {
 				<ng-template [auSlot]="state.slotHandle" [auSlotProps]="{state, widget, item}"></ng-template>
 				@if (state.showValueLabels && !state.combinedLabelDisplay) {
-					<div [auUse]="widget.directives.handleLabelDisplayDirective" [auUseParams]="{index: i}">
+					<div [auUse]="[widget.directives.handleLabelDisplayDirective, {index: i}]">
 						<ng-template [auSlot]="state.slotLabel" [auSlotProps]="{state, widget, value: state.values[i]}"></ng-template>
 					</div>
 				}

--- a/angular/bootstrap/src/components/toast/toast.component.ts
+++ b/angular/bootstrap/src/components/toast/toast.component.ts
@@ -1,14 +1,13 @@
 import type {SlotContent, TransitionFn} from '@agnos-ui/angular-headless';
 import {
 	BaseWidgetDirective,
-	CachedProperty,
 	ComponentTemplate,
 	SlotDefaultDirective,
 	SlotDirective,
 	UseDirective,
+	UseMultiDirective,
 	auBooleanAttribute,
 	auNumberAttribute,
-	mergeDirectives,
 } from '@agnos-ui/angular-headless';
 import type {WritableSignal} from '@amadeus-it-group/tansu';
 import {writable} from '@amadeus-it-group/tansu';
@@ -88,12 +87,17 @@ const defaultConfig: Partial<ToastProps> = {
 	selector: '[auToast]',
 	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	imports: [SlotDirective, UseDirective, SlotDefaultDirective],
+	imports: [SlotDirective, UseMultiDirective, SlotDefaultDirective],
 	template: ` <ng-template [auSlotDefault]="defaultSlots">
 			<ng-content></ng-content>
 		</ng-template>
 		@if (!state().hidden) {
-			<div class="toast" [class.d-flex]="!state().slotHeader" [class.toast-dismissible]="state().dismissible" [auUse]="toastDirective">
+			<div
+				class="toast"
+				[class.d-flex]="!state().slotHeader"
+				[class.toast-dismissible]="state().dismissible"
+				[auUseMulti]="[widget.directives.autoHideDirective, widget.directives.transitionDirective, widget.directives.bodyDirective]"
+			>
 				<ng-template [auSlot]="state().slotStructure" [auSlotProps]="{state: state(), widget}"></ng-template>
 			</div>
 		}`,
@@ -195,15 +199,6 @@ export class ToastComponent extends BaseWidgetDirective<ToastWidget> implements 
 			onHidden: () => this.hidden.emit(),
 		},
 	});
-
-	@CachedProperty
-	get toastDirective() {
-		return mergeDirectives(
-			this._widget.directives.autoHideDirective,
-			this._widget.directives.transitionDirective,
-			this._widget.directives.bodyDirective,
-		);
-	}
 
 	ngAfterContentChecked(): void {
 		this._widget.patchSlots({

--- a/angular/demo/bootstrap/src/app/samples/directives/usage.route.ts
+++ b/angular/demo/bootstrap/src/app/samples/directives/usage.route.ts
@@ -8,7 +8,7 @@ import {createSampleDirective} from '@agnos-ui/common/samples/directives/sample-
 	standalone: true,
 	imports: [UseDirective, FormsModule],
 	template: `
-		<div [auUse]="createSampleDirective" [auUseParams]="config">
+		<div [auUse]="[createSampleDirective, config]">
 			<button class="btn btn-primary" id="test">button 1</button>
 			<button class="btn btn-primary" id="test2">button 2</button>
 		</div>

--- a/angular/demo/bootstrap/src/app/samples/navmanager/navmanager.route.ts
+++ b/angular/demo/bootstrap/src/app/samples/navmanager/navmanager.route.ts
@@ -8,25 +8,11 @@ import {Component, Input} from '@angular/core';
 	imports: [AgnosUIAngularModule],
 	template: `
 		<div class="d-flex demo-navmanager-line">
-			<input [auUse]="navManager.directive" [auUseParams]="navManagerConfig" type="text" [value]="text" class="form-control me-1" />
-			<span [auUse]="navManager.directive" [auUseParams]="navManagerConfig" tabindex="-1" class="form-control w-auto me-1">{{ text }}</span>
-			<input
-				[auUse]="navManager.directive"
-				[auUseParams]="navManagerConfig"
-				tabindex="-1"
-				type="checkbox"
-				class="form-check-input align-self-center me-1"
-			/>
-			<input
-				[auUse]="navManager.directive"
-				[auUseParams]="navManagerConfig"
-				tabindex="-1"
-				type="text"
-				[value]="text"
-				disabled
-				class="form-control me-1"
-			/>
-			<input [auUse]="navManager.directive" [auUseParams]="navManagerConfig" tabindex="-1" type="text" [value]="text" class="form-control me-1" />
+			<input [auUse]="[navManager.directive, navManagerConfig]" type="text" [value]="text" class="form-control me-1" />
+			<span [auUse]="[navManager.directive, navManagerConfig]" tabindex="-1" class="form-control w-auto me-1">{{ text }}</span>
+			<input [auUse]="[navManager.directive, navManagerConfig]" tabindex="-1" type="checkbox" class="form-check-input align-self-center me-1" />
+			<input [auUse]="[navManager.directive, navManagerConfig]" tabindex="-1" type="text" [value]="text" disabled class="form-control me-1" />
+			<input [auUse]="[navManager.directive, navManagerConfig]" tabindex="-1" type="text" [value]="text" class="form-control me-1" />
 		</div>
 	`,
 })

--- a/angular/demo/bootstrap/src/app/samples/navmanager/navmanagerWithSelector.route.ts
+++ b/angular/demo/bootstrap/src/app/samples/navmanager/navmanagerWithSelector.route.ts
@@ -7,7 +7,7 @@ import {Component, Input} from '@angular/core';
 	selector: 'app-navmanager-line',
 	imports: [AgnosUIAngularModule],
 	template: `
-		<div class="d-flex demo-navmanager-line" [auUse]="navManager.directive" [auUseParams]="navManagerConfig">
+		<div class="d-flex demo-navmanager-line" [auUse]="[navManager.directive, navManagerConfig]">
 			<input type="text" [value]="text" class="form-control me-1" />
 			<span tabindex="-1" class="form-control w-auto me-1">{{ text }}</span>
 			<input tabindex="-1" type="checkbox" class="form-check-input align-self-center me-1" />

--- a/angular/demo/bootstrap/src/app/samples/slider/coffee-slider.component.ts
+++ b/angular/demo/bootstrap/src/app/samples/slider/coffee-slider.component.ts
@@ -24,7 +24,7 @@ import {take} from 'rxjs';
 				</div>
 			</div>
 		</div>
-		<button class="coffee-indicator" [auUse]="widget.directives.handleDirective" [auUseParams]="{item: state.sortedHandles[0]}">
+		<button class="coffee-indicator" [auUse]="[widget.directives.handleDirective, {item: state.sortedHandles[0]}]">
 			{{ '' + state.sortedHandles[0].value }}
 		</button>
 	`,

--- a/angular/demo/bootstrap/src/app/samples/slider/custom-handle.component.ts
+++ b/angular/demo/bootstrap/src/app/samples/slider/custom-handle.component.ts
@@ -11,7 +11,7 @@ import {take} from 'rxjs';
 	},
 	imports: [UseDirective],
 	template: `
-		<button class="custom-handle" [auUse]="widget.directives.handleDirective" [auUseParams]="{item}">
+		<button class="custom-handle" [auUse]="[widget.directives.handleDirective, {item}]">
 			<svg xmlns="http://www.w3.org/2000/svg" fill="var(--bs-slider-handle-color)" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 				<path
 					stroke-linecap="round"

--- a/angular/demo/bootstrap/src/app/samples/transition/collapse.component.ts
+++ b/angular/demo/bootstrap/src/app/samples/transition/collapse.component.ts
@@ -27,7 +27,7 @@ import {UseDirective, collapseVerticalTransition, createTransition, toAngularSig
 				</button>
 			</div>
 			@if (!state().hidden) {
-				<div [auUse]="transition.directives.directive" [auUseParams]="{visible: expanded}" id="collapse-content">
+				<div [auUse]="[transition.directives.directive, {visible: expanded}]" id="collapse-content">
 					<div class="card-body">
 						<ng-content />
 					</div>

--- a/angular/demo/bootstrap/src/app/samples/transition/innerComponent.component.ts
+++ b/angular/demo/bootstrap/src/app/samples/transition/innerComponent.component.ts
@@ -95,8 +95,7 @@ const paramRemoveFromDom$ = writable(true);
 
 			@if ((paramRemoveFromDom$ | async) === false || state().hidden === false) {
 				<div
-					[auUse]="transition.directives.directive"
-					[auUseParams]="{transition: (paramTransition$ | async)!, animated: (paramAnimated$ | async)!}"
+					[auUse]="[transition.directives.directive, {transition: (paramTransition$ | async)!, animated: (paramAnimated$ | async)!}]"
 					style="max-width: 300px;"
 				>
 					<div class="card" style="width: 300px;">

--- a/angular/docs/Directives.md
+++ b/angular/docs/Directives.md
@@ -2,10 +2,9 @@
 
 By default, Angular provides a decorator that marks a class as an Angular directive. They are used to attach custom behavior to elements in the DOM and Directive classes can implement life-cycle hooks to influence their configuration behavior (source: Angular doc).
 
-Agnos provides an utility to use Agnos Directives in Angular, `[auUse]`.
-`[auUse]` directive takes as input an Agnos `Directive`, and takes care of execution, update and destroy of it. This thanks to the life-cycle events provided by Angular (`OnChanges`, `OnDestroy`).
-Unfortunately, a directive cannot take additional properties, hence parameters are given through a second input, `[auUseParams]`, which type is the same as the second argument of the Agnos Directive.
-During the `OnChanges` hook, the directive will be executed for the first time (if the reference of the `Directive`) or the Directive `update` function (if provided) will be executed with the new `auUseParams` input.
+Agnos provides two utilities to use Agnos Directives in Angular, `[auUse]` and `[auUseMulti]`.
+`[auUse]` directive takes as input a single Agnos `Directive` and takes care of execution, update and destroy of it. This thanks to the life-cycle events provided by Angular (`OnChanges`, `OnDestroy`). Similarly, `[auUseMulti]` directive takes as input an array of Agnos `Directive`.
+To provide parameters, replace the corresponding directive (in the value of `[auUse]` or `[auUseMulti]`) by an array containing the directive at position 0 and its parameter at position 1.
 
 ##### Example
 

--- a/angular/headless/src/utils/directive.ts
+++ b/angular/headless/src/utils/directive.ts
@@ -1,4 +1,4 @@
-import type {Directive as AgnosUIDirective, DirectivesAndOptParam} from '@agnos-ui/core/types';
+import type {Directive as AgnosUIDirective, DirectiveAndParam, DirectivesAndOptParam} from '@agnos-ui/core/types';
 import {multiDirective} from '@agnos-ui/core/utils/directive';
 import {isPlatformServer} from '@angular/common';
 import type {OnChanges} from '@angular/core';
@@ -69,16 +69,15 @@ export const useDirectiveForHost = <T>(directive?: AgnosUIDirective<T>, params?:
 })
 export class UseDirective<T> implements OnChanges {
 	@Input('auUse')
-	use: AgnosUIDirective<T> | undefined;
-
-	@Input('auUseParams')
-	params: T | undefined;
+	use: AgnosUIDirective | DirectiveAndParam<T> | undefined;
 
 	readonly #useDirective = useDirectiveForHost<T>();
 
 	/** @inheritdoc */
 	ngOnChanges() {
-		this.#useDirective.update(this.use, this.params);
+		const use = this.use;
+		const [directive, param] = Array.isArray(use) ? use : [use as any];
+		this.#useDirective.update(directive, param);
 	}
 }
 

--- a/angular/headless/src/utils/directive.ts
+++ b/angular/headless/src/utils/directive.ts
@@ -1,4 +1,5 @@
-import type {Directive as AgnosUIDirective} from '@agnos-ui/core/types';
+import type {Directive as AgnosUIDirective, DirectivesAndOptParam} from '@agnos-ui/core/types';
+import {multiDirective} from '@agnos-ui/core/utils/directive';
 import {isPlatformServer} from '@angular/common';
 import type {OnChanges} from '@angular/core';
 import {DestroyRef, Directive, ElementRef, Injector, Input, PLATFORM_ID, afterNextRender, inject, runInInjectionContext} from '@angular/core';
@@ -78,5 +79,21 @@ export class UseDirective<T> implements OnChanges {
 	/** @inheritdoc */
 	ngOnChanges() {
 		this.#useDirective.update(this.use, this.params);
+	}
+}
+
+@Directive({
+	standalone: true,
+	selector: '[auUseMulti]',
+})
+export class UseMultiDirective<T extends any[]> implements OnChanges {
+	@Input('auUseMulti')
+	useMulti: DirectivesAndOptParam<T>;
+
+	readonly #useDirective = useDirectiveForHost<DirectivesAndOptParam<T>>();
+
+	/** @inheritdoc */
+	ngOnChanges() {
+		this.#useDirective.update(multiDirective, this.useMulti);
 	}
 }

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -107,6 +107,9 @@ export type Directive<T = void, U extends SSRHTMLElement = SSRHTMLElement> = (
 	args: T,
 ) => void | {update?: (args: T) => void; destroy?: () => void};
 export type DirectiveAndParam<T, U extends SSRHTMLElement = SSRHTMLElement> = [Directive<T, U>, T];
+export type DirectivesAndOptParam<T extends any[], U extends SSRHTMLElement = SSRHTMLElement> = {
+	[K in keyof T]: Directive<void, U> | DirectiveAndParam<T[K], U>;
+};
 
 export type SlotContent<Props extends object = object> = undefined | null | string | ((props: Props) => string);
 

--- a/docs/01-Headless/03-Directives.md
+++ b/docs/01-Headless/03-Directives.md
@@ -150,11 +150,10 @@ The headless libraries of AgnosUI contain adapters to bind directives in the cor
 
 ### Merge directives
 
-If you are using Svelte, you can have multiple directives by using multiple time the `use` directive. On other frameworks, this is not the case.
 Agnos has a utility `mergeDirectives` to merge directives into one, with a limitation on the argument:
 all directives receive the same argument upon initialization and update.
 Directives are created and updated in the same order as they appear in the arguments list,
 they are destroyed in the reverse order.
 All calls to the directives (to create, update and destroy them) are wrapped in a call to the batch function of tansu
 
-Use directly the `mergeDirectives` function in an Angular component to merge directives are pass them as input to the Angular directive `auUse`. For React, there is a version `useDirectives` instead of the singular one to manage this use case.
+Note that it is not mandatory to use `mergeDirectives` to use multiple directives on the same element as frameworks support using multiple directives on the same element.

--- a/react/bootstrap/src/components/accordion/accordion.tsx
+++ b/react/bootstrap/src/components/accordion/accordion.tsx
@@ -2,7 +2,7 @@ import {Slot} from '@agnos-ui/react-headless/slot';
 import type {ForwardRefExoticComponent, ForwardedRef, PropsWithChildren, RefAttributes} from 'react';
 import {createContext, forwardRef, useContext, useEffect, useImperativeHandle} from 'react';
 import {useWidgetWithConfig} from '../../config';
-import {useClassDirective, useDirectives} from '@agnos-ui/react-headless/utils/directive';
+import {classDirective, useDirectives} from '@agnos-ui/react-headless/utils/directive';
 import type {AdaptSlotContentProps, AdaptWidgetSlots, Directive, WidgetFactory, WidgetProps, WidgetState} from '@agnos-ui/react-headless/types';
 import type {AccordionItemApi} from '@agnos-ui/core-bootstrap/components/accordion';
 import {createAccordion as coreCreateAccordion} from '@agnos-ui/core-bootstrap/components/accordion';
@@ -24,12 +24,12 @@ type AccordionTag = `h${1 | 2 | 3 | 4 | 5 | 6}`;
 const Header = (props: PropsWithChildren<{headerTag: string; directive: Directive}>) => {
 	const re = new RegExp('^h[1-6]$');
 	const Heading = (re.test(props.headerTag) ? props.headerTag : 'h2') as AccordionTag;
-	return <Heading {...useDirectives([useClassDirective('accordion-header'), props.directive])}>{props.children}</Heading>;
+	return <Heading {...useDirectives([classDirective, 'accordion-header'], props.directive)}>{props.children}</Heading>;
 };
 
 const ItemContent = (slotContext: AccordionItemContext) => (
-	<div {...useDirectives([useClassDirective('accordion-collapse'), slotContext.widget.directives.bodyContainerDirective])}>
-		<div {...useDirectives([useClassDirective('accordion-body'), slotContext.widget.directives.bodyDirective])}>
+	<div {...useDirectives([classDirective, 'accordion-collapse'], slotContext.widget.directives.bodyContainerDirective)}>
+		<div {...useDirectives([classDirective, 'accordion-body'], slotContext.widget.directives.bodyDirective)}>
 			<Slot slotContent={slotContext.state.slotItemBody} props={slotContext}></Slot>
 		</div>
 	</div>
@@ -39,7 +39,7 @@ const AccordionDIContext: React.Context<Partial<AccordionApi>> = createContext({
 const DefaultSlotStructure = (slotContext: AccordionItemContext) => (
 	<>
 		<Header directive={slotContext.widget.directives.headerDirective} headerTag={slotContext.state.itemHeadingTag}>
-			<button {...useDirectives([useClassDirective('accordion-button'), slotContext.widget.directives.buttonDirective])}>
+			<button {...useDirectives([classDirective, 'accordion-button'], slotContext.widget.directives.buttonDirective)}>
 				<Slot slotContent={slotContext.state.slotItemHeader} props={slotContext}></Slot>
 			</button>
 		</Header>
@@ -65,7 +65,7 @@ export const AccordionItem: ForwardRefExoticComponent<PropsWithChildren<Partial<
 			widget.api.initDone();
 		}, []);
 		return (
-			<div {...useDirectives([useClassDirective(`accordion-item ${state.itemClass}`), widget.directives.accordionItemDirective])}>
+			<div {...useDirectives([classDirective, `accordion-item ${state.itemClass}`], widget.directives.accordionItemDirective)}>
 				<Slot slotContent={state.slotItemStructure} props={slotContext} />
 			</div>
 		);
@@ -78,7 +78,7 @@ export const Accordion: ForwardRefExoticComponent<PropsWithChildren<Partial<Acco
 		useImperativeHandle(ref, () => widget.api, []);
 		return (
 			<AccordionDIContext.Provider value={widget.api}>
-				<div {...useDirectives([useClassDirective('accordion'), widget.directives.accordionDirective])}>{props.children}</div>
+				<div {...useDirectives([classDirective, 'accordion'], widget.directives.accordionDirective)}>{props.children}</div>
 			</AccordionDIContext.Provider>
 		);
 	},

--- a/react/bootstrap/src/components/alert/alert.tsx
+++ b/react/bootstrap/src/components/alert/alert.tsx
@@ -1,6 +1,6 @@
 import {Slot} from '@agnos-ui/react-headless/slot';
 import {useWidgetWithConfig} from '../../config';
-import {useDirectives, useClassDirective} from '@agnos-ui/react-headless/utils/directive';
+import {useDirectives, classDirective} from '@agnos-ui/react-headless/utils/directive';
 import type {PropsWithChildren, ForwardedRef, ForwardRefExoticComponent, RefAttributes} from 'react';
 import {forwardRef, useImperativeHandle} from 'react';
 import {createAlert as coreCreateAlert} from '@agnos-ui/core-bootstrap/components/alert';
@@ -40,12 +40,13 @@ const defaultConfig: Partial<AlertProps> = {
 const AlertElement = (slotContext: AlertContext) => (
 	<div
 		role="alert"
-		{...useDirectives([
-			useClassDirective(
+		{...useDirectives(
+			[
+				classDirective,
 				`au-alert alert alert-${slotContext.state.type} ${slotContext.state.className} ${slotContext.state.dismissible ? 'alert-dismissible' : ''}`,
-			),
+			],
 			slotContext.widget.directives.transitionDirective,
-		])}
+		)}
 	>
 		<Slot slotContent={slotContext.state.slotStructure} props={slotContext}></Slot>
 	</div>

--- a/react/bootstrap/src/components/modal/modal.tsx
+++ b/react/bootstrap/src/components/modal/modal.tsx
@@ -3,7 +3,7 @@ import type {AdaptSlotContentProps, AdaptWidgetSlots, PropsConfig, WidgetProps, 
 import {toSlotContextWidget} from '@agnos-ui/react-headless/types';
 import {Slot} from '@agnos-ui/react-headless/slot';
 import {useWidgetWithConfig} from '../../config';
-import {useDirective, useClassDirective, useDirectives} from '@agnos-ui/react-headless/utils/directive';
+import {useDirective, classDirective, useDirectives} from '@agnos-ui/react-headless/utils/directive';
 import type {PropsWithChildren, Ref, RefAttributes} from 'react';
 import ReactDOM from 'react-dom/client';
 import {forwardRef, useImperativeHandle} from 'react';
@@ -54,11 +54,11 @@ const defaultConfig: Partial<ModalProps<any>> = {
 };
 
 const BackdropElement = <Data,>({widget}: ModalContext<Data>) => (
-	<div {...useDirectives([useClassDirective('modal-backdrop'), widget.directives.backdropDirective])} />
+	<div {...useDirectives([classDirective, 'modal-backdrop'], widget.directives.backdropDirective)} />
 );
 
 const ModalElement = <Data,>(slotContext: ModalContext<Data>) => (
-	<div {...useDirectives([useClassDirective('modal d-block'), slotContext.widget.directives.modalDirective])}>
+	<div {...useDirectives([classDirective, 'modal d-block'], slotContext.widget.directives.modalDirective)}>
 		<div className="modal-dialog">
 			<div className="modal-content">
 				<Slot slotContent={slotContext.state.slotStructure} props={slotContext} />

--- a/react/bootstrap/src/components/rating/rating.tsx
+++ b/react/bootstrap/src/components/rating/rating.tsx
@@ -1,6 +1,6 @@
 import {Slot} from '@agnos-ui/react-headless/slot';
 import {useWidgetWithConfig} from '../../config';
-import {useDirective, useDirectives, useClassDirective} from '@agnos-ui/react-headless/utils/directive';
+import {useDirective, useDirectives, classDirective} from '@agnos-ui/react-headless/utils/directive';
 import React from 'react';
 import {type RatingDirectives, type StarContext, createRating as coreCreateRating} from '@agnos-ui/core-bootstrap/components/rating';
 import type {AdaptWidgetSlots, WidgetFactory, WidgetProps, WidgetState} from '@agnos-ui/react-headless/types';
@@ -32,7 +32,7 @@ export function Rating(props: Partial<RatingProps>) {
 	} = widget;
 
 	return (
-		<div {...useDirectives([useClassDirective('d-inline-flex'), containerDirective])}>
+		<div {...useDirectives([classDirective, 'd-inline-flex'], containerDirective)}>
 			{state.stars.map((star) => (
 				<Star key={star.index} star={star} state={state} directive={starDirective} />
 			))}

--- a/react/bootstrap/src/components/select/select.tsx
+++ b/react/bootstrap/src/components/select/select.tsx
@@ -2,7 +2,7 @@ import {useWidgetWithConfig} from '../../config';
 import {Slot} from '@agnos-ui/react-headless/slot';
 import type {AdaptSlotContentProps, AdaptWidgetSlots, PropsConfig, WidgetProps, WidgetState} from '@agnos-ui/react-headless/types';
 import {toSlotContextWidget} from '@agnos-ui/react-headless/types';
-import {useClassDirective, useDirectives} from '@agnos-ui/react-headless/utils/directive';
+import {classDirective, useDirectives} from '@agnos-ui/react-headless/utils/directive';
 import type {SyntheticEvent} from 'react';
 import type {ItemContext} from '@agnos-ui/core-bootstrap/components/select';
 import {createSelect as coreCreateSelect} from '@agnos-ui/core-bootstrap/components/select';
@@ -61,7 +61,7 @@ function Rows<Item>({slotContext, menuId}: {slotContext: SelectContext<Item>; me
 			id={menuId}
 			data-popper-placement={placement}
 			onMouseDown={preventDefault}
-			{...useDirectives([useClassDirective(`dropdown-menu show ${menuClassName}`), hasFocusDirective, floatingDirective])}
+			{...useDirectives([classDirective, `dropdown-menu show ${menuClassName}`], hasFocusDirective, floatingDirective)}
 		>
 			{state.visibleItems.map((itemContext) => {
 				const {id} = itemContext;
@@ -104,13 +104,13 @@ export function Select<Item>(props: Partial<SelectProps<Item>>) {
 		directives: {hasFocusDirective, referenceDirective, inputContainerDirective},
 	} = widget;
 	return (
-		<div {...useDirectives([useClassDirective(`au-select dropdown border border-1 p-1 mb-3 d-block ${className}`), referenceDirective])}>
+		<div {...useDirectives([classDirective, `au-select dropdown border border-1 p-1 mb-3 d-block ${className}`], referenceDirective)}>
 			<div
 				role="combobox"
 				aria-controls={menuId}
 				aria-haspopup="listbox"
 				aria-expanded={open}
-				{...useDirectives([useClassDirective('d-flex align-items-center flex-wrap'), hasFocusDirective, inputContainerDirective])}
+				{...useDirectives([classDirective, 'd-flex align-items-center flex-wrap'], hasFocusDirective, inputContainerDirective)}
 			>
 				<Badges slotContext={slotContext}></Badges>
 				<input

--- a/react/bootstrap/src/components/toast/toast.tsx
+++ b/react/bootstrap/src/components/toast/toast.tsx
@@ -1,6 +1,6 @@
 import {useWidgetWithConfig} from '../../config';
 import {Slot} from '@agnos-ui/react-headless/slot';
-import {useDirectives, useClassDirective} from '@agnos-ui/react-headless/utils/directive';
+import {useDirectives, classDirective} from '@agnos-ui/react-headless/utils/directive';
 import type {ForwardRefExoticComponent, PropsWithChildren, RefAttributes} from 'react';
 import {forwardRef, useImperativeHandle} from 'react';
 import type {AdaptSlotContentProps, AdaptWidgetSlots, WidgetFactory, WidgetProps, WidgetState} from '@agnos-ui/react-headless/types';
@@ -19,13 +19,13 @@ const ToastHeader = (slotContext: ToastContext) => (
 	<div className="toast-header">
 		<Slot slotContent={slotContext.state.slotHeader} props={slotContext} />
 		{slotContext.state.dismissible && (
-			<button {...useDirectives([useClassDirective('btn-close me-0 ms-auto'), slotContext.widget.directives.closeButtonDirective])} />
+			<button {...useDirectives([classDirective, 'btn-close me-0 ms-auto'], slotContext.widget.directives.closeButtonDirective)} />
 		)}
 	</div>
 );
 
 const ToastCloseButtonNoHeader = (slotContext: ToastContext) => (
-	<button {...useDirectives([useClassDirective('btn-close btn-close-white me-2 m-auto'), slotContext.widget.directives.closeButtonDirective])} />
+	<button {...useDirectives([classDirective, 'btn-close btn-close-white me-2 m-auto'], slotContext.widget.directives.closeButtonDirective)} />
 );
 
 const DefaultSlotStructure = (slotContext: ToastContext) => (
@@ -45,12 +45,12 @@ const defaultConfig: Partial<ToastProps> = {
 
 const ToastElement = (slotContext: ToastContext) => (
 	<div
-		{...useDirectives([
-			useClassDirective(`toast ${slotContext.state.dismissible ? 'toast-dismissible' : ''} ${!slotContext.state.slotHeader ? 'd-flex' : ''}`),
+		{...useDirectives(
+			[classDirective, `toast ${slotContext.state.dismissible ? 'toast-dismissible' : ''} ${!slotContext.state.slotHeader ? 'd-flex' : ''}`],
 			slotContext.widget.directives.transitionDirective,
 			slotContext.widget.directives.autoHideDirective,
 			slotContext.widget.directives.bodyDirective,
-		])}
+		)}
 	>
 		<Slot slotContent={slotContext.state.slotStructure} props={slotContext} />
 	</div>

--- a/react/headless/src/utils/directive.ts
+++ b/react/headless/src/utils/directive.ts
@@ -1,25 +1,10 @@
-import type {Directive, DirectiveAndParam} from '@agnos-ui/core/types';
-import {attributesData, bindDirective, classDirective, mergeDirectives} from '@agnos-ui/core/utils/directive';
-import {writable} from '@amadeus-it-group/tansu';
+import type {Directive, DirectivesAndOptParam} from '@agnos-ui/core/types';
+import {attributesData, multiDirective} from '@agnos-ui/core/utils/directive';
 import {BROWSER} from 'esm-env';
 import type {RefCallback} from 'react';
-import {useCallback, useMemo, useRef} from 'react';
+import {useCallback, useRef} from 'react';
 
 export * from '@agnos-ui/core/utils/directive';
-
-/**
- * Returns a class directive.
- * @param className - class name to use
- * @returns a class directive, to be used with {@link useDirectives}.
- */
-export const useClassDirective = (className: string) => {
-	const {directive, className$} = useMemo(() => {
-		const className$ = writable('');
-		return {directive: bindDirective(classDirective, className$), className$};
-	}, []);
-	className$.set(className);
-	return directive;
-};
 
 const attributesMap = new Map([
 	['tabindex', 'tabIndex'],
@@ -60,7 +45,7 @@ const booleanAttributes = new Set([
  * @param directives - List of directives to generate attributes from. Each parameter can be the directive or an array with the directive and its parameter
  * @returns JSON object with key/value pairs to be applied on a JSX node.
  */
-export function directiveAttributes<T extends any[]>(...directives: {[K in keyof T]: DirectiveAndParam<T[K]> | Directive<void>}) {
+export function directiveAttributes<T extends any[]>(...directives: DirectivesAndOptParam<T>) {
 	const reactAttributes: Record<string, any> = {};
 	const {attributes, style, classNames} = attributesData(...directives);
 
@@ -124,13 +109,8 @@ export const useDirective: {
  * Allows to attach multiple directives to the current react component.
  *
  * @param directives - directives
- * @param args - the args to pass to the directives
  * @returns the ref callback
  */
-export const useDirectives: {
-	(directives: Directive[]): {ref: RefCallback<HTMLElement>};
-	<T>(directives: Directive<T>[], args: T): {ref: RefCallback<HTMLElement>};
-} = <T>(directives: Directive<T>[], args?: T): {ref: RefCallback<HTMLElement>} => {
-	const mergedDirectives = useMemo(() => mergeDirectives(...directives), directives);
-	return useDirective(mergedDirectives, args as any);
-};
+export const useDirectives: <T extends any[]>(...directives: DirectivesAndOptParam<T>) => {ref: RefCallback<HTMLElement>} = BROWSER
+	? (...directives) => useDirective(multiDirective, directives)
+	: (directiveAttributes as any);


### PR DESCRIPTION
This PR adds the `multiDirective` directive in the core that can take as a parameter an array of directives to apply, optionally with their parameters: `[[myDirectiveWithParam, myParam], myDirectiveWithoutParam]`.
Using this directive, it is easy to implement in all frameworks the support for multiple directives when support for only one directive is already implemented.
This PR changes the `useDirectives` hook in react to now use `multiDirective` instead of `mergeDirectives` (with a change in its signature).
This PR also changes the `[auUse]` directive in Angular to also use `multiDirective` and provide multi-directive support in Angular (this is a breaking change).