### PR TITLE
fix: prevent tansu from being included in the build of core-bootstrap

### DIFF
--- a/core-bootstrap/vite.config.ts
+++ b/core-bootstrap/vite.config.ts
@@ -3,13 +3,13 @@ import {dirname} from 'path';
 import {fileURLToPath} from 'url';
 import type {UserConfig} from 'vite';
 import {defineConfig} from 'vite';
-import {dependencies, exports as pkgExports} from './package.json';
+import {dependencies, peerDependencies, exports as pkgExports} from './package.json';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const pathRegExp = /\\/g;
 const normalizePath = (str: string) => str.replace(pathRegExp, '/');
-const externalDependencies = [...Object.keys(dependencies)];
+const externalDependencies = [...Object.keys(dependencies), ...Object.keys(peerDependencies)];
 
 // https://vitejs.dev/config/
 export default defineConfig(async (): Promise<UserConfig> => {


### PR DESCRIPTION
This PR removes the duplication of [`@amadeus-it-group/tansu`](https://github.com/AmadeusITGroup/tansu), which can lead to strange errors (`computed` store not being recomputed when its dependencies change, because it comes from a different instance of `@amadeus-it-group/tansu`).
This currently happens in the carousel and the collapse bootstrap components (both use `@amadeus-it-group/tansu` from `@agnos-ui/core-bootstrap`).