### PR TITLE
refactor(stackblitz): install bootstrap from npm instead of using the CDN

### DIFF
--- a/demo/src/lib/stackblitz/angular-bootstrap/index.html
+++ b/demo/src/lib/stackblitz/angular-bootstrap/index.html
@@ -4,12 +4,6 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>AgnosUI angular stackblitz demo</title>
-		<link
-			href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-			rel="stylesheet"
-			integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-			crossorigin="anonymous"
-		/>
 	</head>
 	<body>
 		<div id="root" class="container p-3">

--- a/demo/src/lib/stackblitz/angular-bootstrap/package-lock.json
+++ b/demo/src/lib/stackblitz/angular-bootstrap/package-lock.json
@@ -21,6 +21,7 @@
 				"@angular/platform-browser-dynamic": "^19.0.0",
 				"@angular/router": "^19.0.0",
 				"@floating-ui/dom": "^1.6.12",
+				"bootstrap": "^5.3.3",
 				"bootstrap-icons": "^1.11.3",
 				"rxjs": "^7.8.1",
 				"tslib": "^2.8.1",
@@ -2716,6 +2717,18 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/@popperjs/core": {
+			"version": "2.11.8",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/popperjs"
+			}
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.34.8",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
@@ -3296,6 +3309,26 @@
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/bootstrap": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+			"integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/twbs"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/bootstrap"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@popperjs/core": "^2.11.8"
+			}
 		},
 		"node_modules/bootstrap-icons": {
 			"version": "1.11.3",

--- a/demo/src/lib/stackblitz/angular-bootstrap/package.json
+++ b/demo/src/lib/stackblitz/angular-bootstrap/package.json
@@ -24,6 +24,7 @@
 		"@angular/platform-browser-dynamic": "^19.0.0",
 		"@angular/router": "^19.0.0",
 		"@floating-ui/dom": "^1.6.12",
+		"bootstrap": "^5.3.3",
 		"bootstrap-icons": "^1.11.3",
 		"rxjs": "^7.8.1",
 		"tslib": "^2.8.1",

--- a/demo/src/lib/stackblitz/angular-bootstrap/src/main.css
+++ b/demo/src/lib/stackblitz/angular-bootstrap/src/main.css
@@ -1,1 +1,2 @@
+@import 'bootstrap/dist/css/bootstrap.min.css';
 @import '@agnos-ui/core-bootstrap/css/agnosui.css';

--- a/demo/src/lib/stackblitz/react-bootstrap/index.html
+++ b/demo/src/lib/stackblitz/react-bootstrap/index.html
@@ -4,12 +4,6 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>AgnosUI react stackblitz demo</title>
-		<link
-			href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-			rel="stylesheet"
-			integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-			crossorigin="anonymous"
-		/>
 	</head>
 	<body>
 		<div id="root" class="container p-3"></div>

--- a/demo/src/lib/stackblitz/react-bootstrap/package-lock.json
+++ b/demo/src/lib/stackblitz/react-bootstrap/package-lock.json
@@ -13,6 +13,7 @@
 				"@types/react": "^19.0.0",
 				"@types/react-dom": "^19.0.0",
 				"@vitejs/plugin-react": "^4.3.4",
+				"bootstrap": "^5.3.3",
 				"bootstrap-icons": "^1.11.3",
 				"react": "^19.0.0",
 				"react-dom": "^19.0.0",
@@ -1132,6 +1133,18 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@popperjs/core": {
+			"version": "2.11.8",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/popperjs"
+			}
+		},
 		"node_modules/@rollup/pluginutils": {
 			"version": "5.1.4",
 			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
@@ -1757,6 +1770,26 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
 			"license": "Python-2.0"
+		},
+		"node_modules/bootstrap": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+			"integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/twbs"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/bootstrap"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@popperjs/core": "^2.11.8"
+			}
 		},
 		"node_modules/bootstrap-icons": {
 			"version": "1.11.3",

--- a/demo/src/lib/stackblitz/react-bootstrap/package.json
+++ b/demo/src/lib/stackblitz/react-bootstrap/package.json
@@ -14,6 +14,7 @@
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
 		"@vitejs/plugin-react": "^4.3.4",
+		"bootstrap": "^5.3.3",
 		"bootstrap-icons": "^1.11.3",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",

--- a/demo/src/lib/stackblitz/react-bootstrap/src/main.css
+++ b/demo/src/lib/stackblitz/react-bootstrap/src/main.css
@@ -1,1 +1,2 @@
+@import 'bootstrap/dist/css/bootstrap.min.css';
 @import '@agnos-ui/core-bootstrap/css/agnosui.css';

--- a/demo/src/lib/stackblitz/svelte-bootstrap/index.html
+++ b/demo/src/lib/stackblitz/svelte-bootstrap/index.html
@@ -4,12 +4,6 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>AgnosUI svelte stackblitz demo</title>
-		<link
-			href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-			rel="stylesheet"
-			integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-			crossorigin="anonymous"
-		/>
 	</head>
 	<body>
 		<div id="root" class="container p-3"></div>

--- a/demo/src/lib/stackblitz/svelte-bootstrap/package-lock.json
+++ b/demo/src/lib/stackblitz/svelte-bootstrap/package-lock.json
@@ -12,6 +12,7 @@
 				"@floating-ui/dom": "^1.6.12",
 				"@sveltejs/vite-plugin-svelte": "^5.0.1",
 				"@tsconfig/svelte": "^5.0.4",
+				"bootstrap": "^5.3.3",
 				"bootstrap-icons": "^1.11.3",
 				"sass": "^1.82.0",
 				"svelte": "^5.16.0",
@@ -858,6 +859,18 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@popperjs/core": {
+			"version": "2.11.8",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/popperjs"
+			}
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.34.9",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.9.tgz",
@@ -1219,6 +1232,26 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/bootstrap": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+			"integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/twbs"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/bootstrap"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@popperjs/core": "^2.11.8"
 			}
 		},
 		"node_modules/bootstrap-icons": {

--- a/demo/src/lib/stackblitz/svelte-bootstrap/package.json
+++ b/demo/src/lib/stackblitz/svelte-bootstrap/package.json
@@ -13,6 +13,7 @@
 		"@floating-ui/dom": "^1.6.12",
 		"@sveltejs/vite-plugin-svelte": "^5.0.1",
 		"@tsconfig/svelte": "^5.0.4",
+		"bootstrap": "^5.3.3",
 		"bootstrap-icons": "^1.11.3",
 		"sass": "^1.82.0",
 		"svelte": "^5.16.0",

--- a/demo/src/lib/stackblitz/svelte-bootstrap/src/main.css
+++ b/demo/src/lib/stackblitz/svelte-bootstrap/src/main.css
@@ -1,1 +1,2 @@
+@import 'bootstrap/dist/css/bootstrap.min.css';
 @import '@agnos-ui/core-bootstrap/css/agnosui.css';


### PR DESCRIPTION
This fixes flaky stackblitz e2e tests (caused by the CDN returning an error).