### PR TITLE
fix(angular, carousel): exported type of plugins input

### DIFF
--- a/angular/bootstrap/ng-package.json
+++ b/angular/bootstrap/ng-package.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
-	"allowedNonPeerDependencies": ["@agnos-ui/angular-headless", "@amadeus-it-group/tansu", "@agnos-ui/core-bootstrap"],
+	"allowedNonPeerDependencies": ["@agnos-ui/angular-headless", "@agnos-ui/core-bootstrap"],
 	"lib": {
 		"entryFile": "src/index.ts"
 	}

--- a/angular/bootstrap/src/components/carousel/carousel.component.ts
+++ b/angular/bootstrap/src/components/carousel/carousel.component.ts
@@ -11,6 +11,7 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type {CarouselContext, CarouselSlideContext, CarouselWidget, CarouselProps} from './carousel.gen';
 import {createCarousel} from './carousel.gen';
+import type {InputSignal} from '@angular/core';
 import {ChangeDetectionStrategy, Component, contentChild, Directive, inject, input, TemplateRef, viewChild} from '@angular/core';
 import {callWidgetFactory} from '../../config';
 import type {EmblaPluginType} from 'embla-carousel';
@@ -212,7 +213,7 @@ export class CarouselComponent<SlideData extends {id: string}> extends BaseWidge
 	 * Plugins to extend the carousel with additional features
 	 * @defaultValue `[]`
 	 */
-	readonly plugins = input<EmblaPluginType[]>(undefined, {alias: 'auPlugins'});
+	readonly plugins: InputSignal<EmblaPluginType[] | undefined> = input<EmblaPluginType[]>(undefined, {alias: 'auPlugins'});
 
 	/**
 	 * Align the slides relative to the carousel viewport

--- a/angular/headless/ng-package.json
+++ b/angular/headless/ng-package.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
-	"allowedNonPeerDependencies": ["@agnos-ui/core", "@amadeus-it-group/tansu"],
+	"allowedNonPeerDependencies": ["@agnos-ui/core"],
 	"lib": {
 		"entryFile": "src/index.ts"
 	}


### PR DESCRIPTION
The exported type of `plugins` input was:
```typescript
readonly plugins: import("@angular/core").InputSignal<import("embla-carousel").CreatePluginType<import("node_modules/embla-carousel/esm/components/Plugins").LoosePluginType, {}>[] | undefined>;
```
instead of
```typescript
readonly plugins: InputSignal<EmblaPluginType[] | undefined>;
```