### PR TITLE
fix: wrong error message after name changed (createResizeObserverMap)

### DIFF
--- a/core/src/services/resizeObserver.spec.ts
+++ b/core/src/services/resizeObserver.spec.ts
@@ -93,7 +93,7 @@ describe(`ResizeObserver service`, () => {
 
 		expect(consoleErrorSpy).toHaveBeenCalledOnce();
 		expect(consoleErrorSpy.mock.calls[0][0]).toBe(
-			'createResizeObserver directive can only be applied to a single element. Use createResizeObserverArray for multiple elements.',
+			'createResizeObserver directive can only be applied to a single element. Use createResizeObserverMap for multiple elements.',
 		);
 
 		//textarea default values

--- a/core/src/services/resizeObserver.ts
+++ b/core/src/services/resizeObserver.ts
@@ -54,7 +54,7 @@ export const createResizeObserver = (): {
 		if (firstElement === null) {
 			firstElement = element;
 		} else {
-			console.error('createResizeObserver directive can only be applied to a single element. Use createResizeObserverArray for multiple elements.');
+			console.error('createResizeObserver directive can only be applied to a single element. Use createResizeObserverMap for multiple elements.');
 			return;
 		}
 


### PR DESCRIPTION
cf last change in #1254 