### PR TITLE
chore: update Renovate GitHub Action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: renovatebot/github-action@v43.0.20
+      - uses: renovatebot/github-action@v46.1.13
         with:
           configurationFile: selfhost-renovate.json
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates the self-hosted Renovate workflow from `renovatebot/github-action@v43.0.20` to `v46.1.13`.

This keeps the scheduled/manual Renovate job on the current GitHub Action release while preserving the existing `selfhost-renovate.json` configuration and `GITHUB_TOKEN` wiring.

Verification:
- `git diff --check`
